### PR TITLE
test: avoid repetition in test scaffolding code

### DIFF
--- a/spec/fiddle-bisect-parser.spec.ts
+++ b/spec/fiddle-bisect-parser.spec.ts
@@ -1,32 +1,30 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import {
   FiddleBisectResult,
   parseFiddleBisectOutput,
 } from '../src/server/fiddle-bisect-parser';
-import * as fs from 'fs';
 
 describe('fiddle-bisect-parser', () => {
+  function getBisectResult(basename: string) {
+    const filename = path.resolve('./spec/fixtures', basename);
+    const output = fs.readFileSync(filename).toString();
+    return parseFiddleBisectOutput(output) as FiddleBisectResult & {
+      success: true;
+    };
+  }
+
   describe('parseFiddleBisectOutput()', () => {
     it('parses a success', () => {
-      const output = fs
-        .readFileSync('./spec/fixtures/fiddle-bisect-output-success.txt')
-        .toString();
-      const result = parseFiddleBisectOutput(output) as FiddleBisectResult & {
-        success: true;
-      };
-
+      const result = getBisectResult('fiddle-bisect-output-success.txt');
       expect(result.success).toBe(true);
       expect(result.goodVersion).toBe('10.3.2');
       expect(result.badVersion).toBe('10.4.0');
     });
 
     it('parses a failure', () => {
-      const output = fs
-        .readFileSync('./spec/fixtures/fiddle-bisect-output-failed.txt')
-        .toString();
-      const result = parseFiddleBisectOutput(output) as FiddleBisectResult & {
-        success: false;
-      };
-
+      const result = getBisectResult('fiddle-bisect-output-failed.txt');
       expect(result.success).toBe(false);
       expect(result).not.toHaveProperty('goodVersion');
       expect(result).not.toHaveProperty('badVersion');

--- a/spec/issue-parser.spec.ts
+++ b/spec/issue-parser.spec.ts
@@ -1,80 +1,65 @@
-import { parseIssueBody } from '../src/util/issue-parser';
-import * as fs from 'fs';
 import * as SemVer from 'semver';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { parseIssueBody } from '../src/util/issue-parser';
 
 describe('issue-parser', () => {
   describe('parseIssueBody()', () => {
-    it('extracts a version range and a gist from an issue string', () => {
-      const issueBody = fs.readFileSync('./spec/fixtures/issue.md').toString();
-      const { goodVersion, badVersion, gistId } = parseIssueBody(issueBody);
+    function getIssueBody(basename: string) {
+      const filename = path.resolve('./spec/fixtures/', basename);
+      return fs.readFileSync(filename).toString();
+    }
 
+    function expectValidRegressionReport(issueBody: string) {
+      const { goodVersion, badVersion, gistId } = parseIssueBody(issueBody);
       expect(SemVer.valid(goodVersion)).toBe('13.0.0');
       expect(SemVer.valid(badVersion)).toBe('12.0.0');
       expect(typeof gistId).toBe('string');
+    }
+
+    function expectIssueToThrow(name: string, errmsg: string) {
+      expect(() => parseIssueBody(getIssueBody(name))).toThrow(errmsg);
+    }
+
+    it('extracts a version range and a gist from an issue string', () => {
+      expectValidRegressionReport(getIssueBody('issue.md'));
     });
 
     it('attempts to coerce input versions into semver', () => {
-      const issueBody = fs
-        .readFileSync('./spec/fixtures/issue-versions-non-semantic.md')
-        .toString();
-      const { goodVersion, badVersion, gistId } = parseIssueBody(issueBody);
-
-      expect(SemVer.valid(goodVersion)).toBe('13.0.0');
-      expect(SemVer.valid(badVersion)).toBe('12.0.0');
-      expect(typeof gistId).toBe('string');
+      const name = 'issue-versions-non-semantic.md';
+      expectValidRegressionReport(getIssueBody(name));
     });
 
     it('handles a trailing slash at the end of the gist URL', () => {
-      const issueBody = fs
-        .readFileSync('./spec/fixtures/issue-gist-trailing-slash.md')
-        .toString();
-      const { goodVersion, badVersion, gistId } = parseIssueBody(issueBody);
-
-      expect(SemVer.valid(goodVersion)).toBe('13.0.0');
-      expect(SemVer.valid(badVersion)).toBe('12.0.0');
-      expect(typeof gistId).toBe('string');
+      const name = 'issue-gist-trailing-slash.md';
+      expectValidRegressionReport(getIssueBody(name));
     });
 
     it('handles gists', () => {
-      const issueBody = fs
-        .readFileSync('./spec/fixtures/issue-gist-invalid.md')
-        .toString();
-      expect(() => {
-        parseIssueBody(issueBody);
-      }).toThrowError(
-        'Testcase URL https://github.com/erickzhao/electron is invalid',
+      expectIssueToThrow(
+        'issue-gist-invalid.md',
+        'URL https://github.com/erickzhao/electron is invalid',
       );
     });
 
-    it('throws an error if one or more required parameters is missing', () => {
-      const issueBody = fs
-        .readFileSync('./spec/fixtures/issue-missing-info.md')
-        .toString();
-      expect(() => {
-        parseIssueBody(issueBody);
-      }).toThrowError(
+    it('throws if parameters are missing', () => {
+      expectIssueToThrow(
+        'issue-missing-info.md',
         'One or more required parameters is missing in issue body',
       );
     });
 
-    it('throws if version numbers cannot be coerced', () => {
-      const issueBody = fs
-        .readFileSync('./spec/fixtures/issue-versions-invalid.md')
-        .toString();
-      expect(() => {
-        parseIssueBody(issueBody);
-      }).toThrowError(
+    it('throws if version numbers are invalid', () => {
+      expectIssueToThrow(
+        'issue-versions-invalid.md',
         'One or more required parameters is missing in issue body',
       );
     });
 
     it('throws if testcase gist is invalid', () => {
-      const issueBody = fs
-        .readFileSync('./spec/fixtures/issue-gist-invalid.md')
-        .toString();
-      expect(() => {
-        parseIssueBody(issueBody);
-      }).toThrowError(
+      expectIssueToThrow(
+        'issue-gist-invalid.md',
         'Testcase URL https://github.com/erickzhao/electron is invalid',
       );
     });


### PR DESCRIPTION
In tests, move repeated code into reusable functions to avoid repetition.

There's not much to this PR; it's simple refactoring I did while reading last weeks' commits