### PR TITLE
fix: broker test import URLSearchParams explicitly

### DIFF
--- a/modules/broker/test/broker.spec.ts
+++ b/modules/broker/test/broker.spec.ts
@@ -2,6 +2,7 @@ import * as semver from 'semver';
 import dayjs from 'dayjs';
 import fetch from 'node-fetch';
 import { v4 as mkuuid, validate as is_uuid } from 'uuid';
+import { URLSearchParams } from 'url';
 
 import { Broker } from '../src/broker';
 import { Server } from '../src/server';

--- a/modules/shared/tsconfig.base.json
+++ b/modules/shared/tsconfig.base.json
@@ -12,5 +12,6 @@
     "module": "CommonJS",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
Works around an upstream typing issues with URL, URLSearchParams. Without this, the broker's tests fail when a type for URLSearchParams can't be found.

Looks like this might've broken as a side-effect of specifying ES2019 in tsconfig.base.json in f6254f89 ?

Xref: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960