### PR TITLE
feat: broker serve both http and https

### DIFF
--- a/broker.config.js
+++ b/broker.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  server: {
+    cert:
+      process.env.BROKER_CERT ||
+      '/etc/letsencrypt/live/bugbot.electronjs.org/fullchain.pem',
+    key:
+      process.env.BROKER_KEY ||
+      '/etc/letsencrypt/live/bugbot.electronjs.org/privkey.pem',
+    port: Number.parseInt(process.env.BROKER_PORT, 10) || 8080,
+    sport: Number.parseInt(process.env.BROKER_SPORT, 10) || 8443,
+  },
+};

--- a/modules/broker/package.json
+++ b/modules/broker/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@electron/bugbot-shared": "*",
+    "cosmiconfig": "^7.0.0",
     "dayjs": "^1.10.5",
     "debug": "^4.3.1",
     "etag": "^1.8.1",

--- a/modules/broker/src/main.ts
+++ b/modules/broker/src/main.ts
@@ -1,11 +1,23 @@
+import Debug from 'debug';
+import { cosmiconfigSync } from 'cosmiconfig';
+
 import { Broker } from './broker';
 import { Server } from './server';
 import { Task } from './task';
 
+const debug = Debug('broker:server');
+
+// load settings from a broker config file
+const searchResult = cosmiconfigSync('broker').search();
+if (!searchResult) throw new Error('broker config not found');
+debug(`using broker config file '${searchResult.filepath}'`);
+const { config } = searchResult;
+
+// start the web server
 const broker = new Broker();
 const server = new Server({
+  ...(config?.server || {}),
   broker,
   createBisectTask: Task.createBisectTask,
-  port: Number.parseInt(process.env.PORT, 10) || 9099,
 });
 server.listen();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1051,6 +1051,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
 
+"@types/parse-json@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
+  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
 "@types/pino-http@^5.0.6":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@types/pino-http/-/pino-http-5.4.1.tgz#eec5f7b1857ab188eca13d7451bb50e83cdcf020"
@@ -2012,6 +2017,17 @@ core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cosmiconfig@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
+  integrity sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+  dependencies:
+    "@types/parse-json" "^4.0.0"
+    import-fresh "^3.2.1"
+    parse-json "^5.0.0"
+    path-type "^4.0.0"
+    yaml "^1.10.0"
 
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -6657,6 +6673,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^1.10.0:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@20.x:
   version "20.2.7"


### PR DESCRIPTION
The broker serves http by default. If the cert & keyfiles are set, broker will also serve https.

In addition, the broker's settings (e.g. what port to use) now reside in `broker.config.js` where the bot and runners can pick up the values too.