### PR TITLE
refactor: use process.platform os names

### DIFF
--- a/modules/broker/src/task.ts
+++ b/modules/broker/src/task.ts
@@ -65,7 +65,7 @@ export class Task {
   private static PropertyTests = Object.freeze({
     first: (value: string) => semver.valid(value),
     last: (value: string) => semver.valid(value),
-    os: (value: string) => ['linux', 'mac', 'windows'].includes(value),
+    os: (value: string) => ['darwin', 'linux', 'win32'].includes(value),
     type: (value: string) => ['bisect', 'test'].includes(value),
   });
 

--- a/modules/broker/test/broker.spec.ts
+++ b/modules/broker/test/broker.spec.ts
@@ -215,7 +215,7 @@ describe('broker', () => {
       it('os', async () => {
         const { body: id_os_any } = await postNewBisectJob();
         const { body: id_os_lin } = await postNewBisectJob({ os: 'linux' });
-        await postNewBisectJob({ os: 'windows' });
+        await postNewBisectJob({ os: 'win32' });
 
         const { body: jobs } = await getJobs({ os: 'linux' });
 


### PR DESCRIPTION
For clarity, use the same names that the rest of the Node world is using.
before: 'linux', 'macos', 'windows'
after: 'darwin', 'linux', 'win32'