### PR TITLE
feat: add more filter options when querying jobs

### DIFF
--- a/modules/broker/src/main.ts
+++ b/modules/broker/src/main.ts
@@ -1,23 +1,21 @@
-import Debug from 'debug';
+import debug from 'debug';
 import { cosmiconfigSync } from 'cosmiconfig';
 
-import { Broker } from './broker';
 import { Server } from './server';
-import { Task } from './task';
 
-const debug = Debug('broker:server');
+const d = debug('broker:server');
 
-// load settings from a broker config file
-const searchResult = cosmiconfigSync('broker').search();
-if (!searchResult) throw new Error('broker config not found');
-debug(`using broker config file '${searchResult.filepath}'`);
-const { config } = searchResult;
+export function createServer(): Server {
+  // load settings from a broker config file
+  const searchResult = cosmiconfigSync('broker').search();
+  if (!searchResult) throw new Error('broker config not found');
+  d(`using broker config file '${searchResult.filepath}'`);
+  const { config } = searchResult;
 
-// start the web server
-const broker = new Broker();
-const server = new Server({
-  ...(config?.server || {}),
-  broker,
-  createBisectTask: Task.createBisectTask,
-});
-server.listen();
+  // create the webserver
+  return new Server(config?.server || {});
+}
+
+if (require.main === module) {
+  createServer().start();
+}

--- a/modules/broker/src/task.ts
+++ b/modules/broker/src/task.ts
@@ -1,87 +1,85 @@
 import * as semver from 'semver';
-import { v4 as mkuuid, validate as is_uuid } from 'uuid';
+import { v4 as mkuuid } from 'uuid';
 
 export class Task {
-  public readonly id: string;
+  public readonly id = mkuuid();
   public readonly log: string[] = [];
-  public readonly time_created: Date;
+  public readonly time_created = Date.now();
   public readonly type: string;
-  public bisect_result: string[] | undefined = undefined;
-  public client_data: string | undefined = undefined;
-  public error: string | undefined = undefined;
-  public etag: string | undefined = undefined;
-  public first: string | undefined = undefined;
+  public bisect_range: string[];
+  public client_data: string;
+  public error: string;
+  public etag: string;
   public gist: string;
-  public last: string | undefined = undefined;
-  public os: string;
+  public platform: string;
+  public result_bisect: string[];
   public runner: string;
-  public time_finished: Date | undefined = undefined;
-  public time_started: Date | undefined = undefined;
+  public time_done: Date;
+  public time_started: Date;
 
   constructor(props: Record<string, any>) {
-    // provide default values for any missing required properties
-    if (!is_uuid(props.id)) props.id = mkuuid();
-    if (!props.time_created) props.time_created = Date.now();
-
     for (const [key, val] of Object.entries(props)) {
       this[key] = val;
     }
   }
 
-  public static PackageFields = Object.freeze(new Set(['etag', 'log']));
+  public static PackageFields: ReadonlyArray<string> = ['etag', 'log'] as const;
 
-  public static PublicFields = Object.freeze(
-    new Set([
-      'client_data',
-      'error',
-      'first',
-      'gist',
-      'id',
-      'last',
-      'os',
-      'result_bisect',
-      'runner',
-      'time_created',
-      'time_finished',
-      'time_started',
-      'type',
-    ]),
-  );
+  public static PublicFields: ReadonlyArray<string> = [
+    'bisect_range',
+    'bot_client_data',
+    'error',
+    'gist',
+    'id',
+    'platform',
+    'result_bisect',
+    'runner',
+    'time_created',
+    'time_done',
+    'time_started',
+    'type',
+  ] as const;
 
-  private static ReadonlyProps = Object.freeze(
-    new Set(['id', 'log', 'time_created', 'type']),
-  );
+  public static KnownFields: ReadonlyArray<string> = [
+    ...Task.PackageFields,
+    ...Task.PublicFields,
+  ] as const;
 
-  private static KnownProps = Object.freeze(
-    new Set([...Task.PackageFields.values(), ...Task.PublicFields.values()]),
-  );
+  public static ReadonlyFields: ReadonlyArray<string> = [
+    'id',
+    'log',
+    'time_created',
+    'type',
+  ] as const;
 
   public publicSubset(): Record<string, any> {
     return Object.fromEntries(
-      Object.entries(this).filter(([key]) => Task.PublicFields.has(key)),
+      Object.entries(this).filter(([key]) => Task.PublicFields.includes(key)),
     );
   }
 
   private static PropertyTests = Object.freeze({
-    first: (value: string) => semver.valid(value),
-    last: (value: string) => semver.valid(value),
-    os: (value: string) => ['darwin', 'linux', 'win32'].includes(value),
+    bisect_range: (value: string[]) =>
+      Array.isArray(value) &&
+      value.length === 2 &&
+      value.every((v) => semver.valid(v)),
+    platform: (value: string) => ['darwin', 'linux', 'win32'].includes(value),
     type: (value: string) => ['bisect', 'test'].includes(value),
   });
 
   public static canInit(key: string, value: any): boolean {
-    if (!Task.KnownProps.has(key)) return false;
+    if (!Task.KnownFields.includes(key)) return false;
     const test = Task.PropertyTests[key];
     return !test || test(value);
   }
 
   public static canSet(key: string, value: any): boolean {
-    return Task.canInit(key, value) && !Task.ReadonlyProps.has(key);
+    return Task.canInit(key, value) && !Task.ReadonlyFields.includes(key);
   }
 
   public static createBisectTask(props: Record<string, any>): Task {
     const required_all = ['gist', 'type'];
-    const required_type = new Map([['bisect', ['first', 'last']]]);
+    const required_type = new Map([['bisect', ['bisect_range']]]);
     for (const name of [...required_all, ...required_type.get(props.type)]) {
       if (!props[name]) {
         throw new Error(`missing property: ${name}`);

--- a/modules/runner/src/main.ts
+++ b/modules/runner/src/main.ts
@@ -25,8 +25,7 @@ interface BaseJob {
 
 interface BisectJob extends BaseJob {
   type: 'bisect';
-  first: string;
-  last: string;
+  range: string[],
   result_bisect?: [string, string];
 }
 
@@ -129,7 +128,7 @@ class Runner {
         // Then determine how to run the job and return results
         if (job.type === 'bisect') {
           // Run the bisect
-          const result = await this.runBisect(job.first, job.last, job.gist);
+          const result = await this.runBisect(job.range, job.gist);
 
           // Report the result back to the job
           if (result.success) {
@@ -240,10 +239,10 @@ class Runner {
   }
 
   private runBisect(
-    goodVersion: string,
-    badVersion: string,
+    range: string[],
     gistId: string,
   ): Promise<FiddleBisectResult> {
+    const [goodVersion, badVersion] = range;
     // Call fiddle and instruct it to bisect with the supplied parameters
     return new Promise((resolve, reject) => {
       execFile(


### PR DESCRIPTION
- add better filtering options when querying jobs, e.g. allowing multiple vals in key/value pairs, negation, sub-properties. From the code:

```js
  /**
   * Conventions:
   * - `.` characters in the key delimit an object subtree
   * - `,` characters in the value delimit multiple values
   * - a value of `undefined` matches undefined values
   * - a key ending in `!` negates the filter
   *
   * Examples:
   * - `jobs?foo=bar`          - `o[foo] == bar`
   * - `jobs?foo!=bar`         - `o[foo] != bar`
   * - `jobs?foo=undefined`    - `o[foo] === undefined`
   * - `jobs?foo=bar,baz`      - `o[foo] == bar || o[foo] == baz`
   * - `jobs?foo.bar=baz`      - `o[foo][bar] == baz`
   * - `jobs?foo!=undefined`   - `o[foo] != undefined`
   * - `jobs?foo!=bar,baz`     - `o[foo] != bar && o[foo] != baz`
   * - `jobs?foo.bar=baz,qux`  - `o[foo][bar] == baz || o[foo][bar] == qux`
   * - `jobs?foo.bar!=baz,qux` - `o[foo][bar] != baz && o[foo][bar] != qux`
   */
```