### PR TITLE
chore(bot): configure heroku procfile

### DIFF
--- a/modules/bot/Procfile
+++ b/modules/bot/Procfile
@@ -1,0 +1,1 @@
+web: yarn workspace @electron/bugbot-bot start

--- a/modules/bot/package.json
+++ b/modules/bot/package.json
@@ -5,6 +5,7 @@
   "main": "dist/github-client.js",
   "scripts": {
     "build": "tsc -b",
+    "heroku-postbuild": "yarn build",
     "start": "probot run ./dist/github-client.js",
     "test": "jest --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:eslint": "eslint modules/*/src/**/*.ts",
     "lint:eslint:fix": "eslint --fix modules/*/src/**/*.ts",
     "lint:prettier": "prettier --check package.json modules/*/package.json modules/*/src/**/*.ts",
-    "lint:prettier:fix": "prettier --write package.json modules/*/package.json modules/*/src/**/*.ts"
+    "lint:prettier:fix": "prettier --write package.json modules/*/package.json modules/*/src/**/*.ts",
+    "heroku-postbuild": "yarn build"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.24.0",


### PR DESCRIPTION
Uses https://elements.heroku.com/buildpacks/heroku/heroku-buildpack-multi-procfile to allow multiple Heroku Procfiles.

Serving the app at https://damp-temple-23212.herokuapp.com/. Currently works off of my test app, but the Heroku Config Vars can be changed to use the actual Electron one.