### PR TITLE
refactor: use probot.Context type in probot client

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import { Probot } from 'probot';
+import { Context, Probot } from 'probot';
 import { inspect } from 'util';
 
 import { env } from '@electron/bugbot-shared/lib/env-vars';
@@ -27,7 +27,11 @@ const brokerBaseURL = env('BROKER_BASE_URL');
  * @param result The result from a Fiddle bisection
  * @param context Probot context object
  */
-async function commentBisectResult(jobId: JobId, result: Result, context: any) {
+async function commentBisectResult(
+  jobId: JobId,
+  result: Result,
+  context: Context,
+) {
   const d = debug('github-client:commentBisectResult');
   const add_labels = new Set<string>();
   const del_labels = new Set<string>([Labels.BugBot.Running]);
@@ -94,7 +98,7 @@ async function commentBisectResult(jobId: JobId, result: Result, context: any) {
  * Takes action based on a comment left on an issue
  * @param context Probot context object
  */
-export async function parseManualCommand(context: any): Promise<void> {
+export async function parseManualCommand(context: Context): Promise<void> {
   const d = debug('github-client:parseManualCommand');
   const api = new BrokerAPI({ baseURL: brokerBaseURL });
 

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -1,5 +1,7 @@
 process.env.BROKER_BASE_URL = 'http://localhost:9099';
 
+import { Context } from 'probot';
+
 import { parseManualCommand } from '../src/github-client';
 import BrokerAPI from '../src/api-client';
 import fixture from './fixtures/issue_comment.created.json';
@@ -39,7 +41,7 @@ describe('github-client', () => {
             body: 'I am commenting!',
           },
         },
-      });
+      } as Context);
 
       expect(mockGetJob).not.toHaveBeenCalled();
     });
@@ -52,7 +54,7 @@ describe('github-client', () => {
             body: '/test stop',
           },
         },
-      });
+      } as Context);
 
       expect(mockGetJob).toHaveBeenCalled();
       expect(mockStopJob).toHaveBeenCalled();
@@ -68,7 +70,7 @@ describe('github-client', () => {
 
       await parseManualCommand({
         payload: fixture,
-      });
+      } as Context);
 
       expect(mockQueueBisectJob).toHaveBeenCalledWith(input);
     });
@@ -79,7 +81,7 @@ describe('github-client', () => {
       });
       await parseManualCommand({
         payload: fixture,
-      });
+      } as Context);
 
       expect(mockQueueBisectJob).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
In the probot client code, type the context parameters as 'probot.Context' instead of as 'any'.

This is a small type safety improvement I found while working on the environment variable PR.