### PR TITLE
fix: broken log URL in issue comments

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -32,6 +32,7 @@ async function commentBisectResult(jobId: JobId, result: Result, context: any) {
   const add_labels = new Set<string>();
   const del_labels = new Set<string>([Labels.BugBot.Running]);
   const paragraphs: string[] = [];
+  const log_url = new URL(`/log/${jobId}`, brokerBaseURL);
 
   switch (result.status) {
     case 'success': {
@@ -39,7 +40,7 @@ async function commentBisectResult(jobId: JobId, result: Result, context: any) {
       paragraphs.push(
         `It looks like this bug was introduced between ${a} and ${b}`,
         `Commits between those versions: https://github.com/electron/electron/compare/v${a}...v${b}`,
-        `For more information, see ${brokerBaseURL}/log/${jobId}`,
+        `For more information, see ${log_url}`,
       );
       add_labels.add(Labels.Bug.Regression);
       // FIXME(any): get the majors in [a..b] and add version labels e.g. 13-x-y
@@ -56,7 +57,7 @@ async function commentBisectResult(jobId: JobId, result: Result, context: any) {
         // FIXME(any): add the link here.
         `${AppName} was unable to complete this bisection. Check the table’s links for more information.`,
         'A maintainer in @wg-releases will need to look into this. When any issues are resolved, BugBot can be restarted by replacing the bugbot/maintainer-needed label with bugbot/test-needed.',
-        `For more information, see ${brokerBaseURL}/log/${jobId}`,
+        `For more information, see ${log_url}`,
       );
       add_labels.add(Labels.BugBot.MaintainerNeeded);
       break;


### PR DESCRIPTION
This fixes the broken log URL that we saw yesterday. The occurs when BROKER_BASE_URL has a trailing slash because the link was built naively with `${base}/path`. It now uses `new URL(/path, base)` which works whether or not there's a trailing slash.