### PR TITLE
feat: sanitize broker responses

### DIFF
--- a/modules/broker/package.json
+++ b/modules/broker/package.json
@@ -13,6 +13,7 @@
     "@electron/bugbot-shared": "*",
     "dayjs": "^1.10.5",
     "debug": "^4.3.1",
+    "escape-html": "^1.0.3",
     "etag": "^1.8.1",
     "express": "^4.17.1",
     "fast-json-patch": "^3.0.0-1",
@@ -20,6 +21,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@types/escape-html": "^1.0.1",
     "node-fetch": "^2.6.1"
   }
 }

--- a/modules/broker/src/log.ts
+++ b/modules/broker/src/log.ts
@@ -4,7 +4,7 @@ import { Task } from './task';
 const ElectronRegex =
   /Electron ((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)/;
 const UrlRegex =
-  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+  /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/;
 const TimestampRegex = /^(\[.*\])\s+(.*)/;
 
 // A handful of text colors that play nice in dark mode.

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -1,8 +1,8 @@
-import * as fs from 'fs';
 import * as http from 'http';
 import * as https from 'https';
 import * as jsonpatch from 'fast-json-patch';
 import * as path from 'path';
+import escapeHtml from 'escape-html';
 import debug from 'debug';
 import create_etag from 'etag';
 import express from 'express';
@@ -63,7 +63,7 @@ export class Server {
     const task = this.broker.getTask(id);
     if (!task) {
       d('404 no such task');
-      res.status(404).send(`Unknown job '${id}'`);
+      res.status(404).send(escapeHtml(`Unknown job '${id}'`));
       return;
     }
 
@@ -78,7 +78,7 @@ export class Server {
       task.logText(req.body);
       res.status(200).end();
     } else {
-      res.status(404).send(`Unknown job '${id}'`);
+      res.status(404).send(escapeHtml(`Unknown job '${id}'`));
     }
   }
 
@@ -87,9 +87,9 @@ export class Server {
     try {
       task = Task.createBisectTask(req.body);
       this.broker.addTask(task);
-      res.status(201).send(task.id);
+      res.status(201).send(escapeHtml(task.id));
     } catch (error) {
-      res.status(422).send(error.message);
+      res.status(422).send(escapeHtml(error.message));
     }
   }
 
@@ -97,7 +97,7 @@ export class Server {
     const id = path.basename(req.url);
     const task = this.broker.getTask(id);
     if (!task) {
-      res.status(404).send(`Unknown job '${id}'`);
+      res.status(404).send(escapeHtml(`Unknown job '${id}'`));
       return;
     }
 
@@ -113,14 +113,14 @@ export class Server {
     const id = path.basename(req.url);
     const task = this.broker.getTask(id);
     if (!task) {
-      res.status(404).send(`Unknown job '${id}'`);
+      res.status(404).send(escapeHtml(`Unknown job '${id}'`));
       return;
     }
 
     const if_header = 'If-Match';
     const if_etag = req.header(if_header);
     if (if_etag && if_etag !== task.etag) {
-      res.status(412).send(`Invalid ${if_header} header: ${if_etag}`);
+      res.status(412).send(escapeHtml(`Invalid ${if_header} header: ${if_etag}`));
       return;
     }
 
@@ -150,7 +150,7 @@ export class Server {
       res.status(200).end();
     } catch (err) {
       d(err);
-      res.status(400).send(err);
+      res.status(400).send(escapeHtml(err.message));
     }
   }
 

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -72,7 +72,7 @@ export class Server {
   }
 
   private putLog(req: express.Request, res: express.Response) {
-    const [, id] = /\/api\/jobs\/(.*)\/log/.exec(req.url);
+    const id = req.path.split('/', 4).pop(); // /api/jobs/${id}/log
     const task = this.broker.getTask(id);
     if (task) {
       task.logText(req.body);

--- a/modules/broker/test/broker.spec.ts
+++ b/modules/broker/test/broker.spec.ts
@@ -480,6 +480,16 @@ describe('broker', () => {
         expect(res.status).toBe(404);
       });
     });
+
+    it('sanitizes its return messages', async () => {
+      const malicious_etag = `<a href="http://www.electronjs.org/">Click Me</a>`;
+      const new_gist = 'new_gist';
+      const response = await patchJob(id, malicious_etag, [
+        { op: 'replace', path: '/gist', value: new_gist },
+      ]);
+      expect(response.status).toBe(412);
+      expect(await response.text()).not.toMatch(malicious_etag);
+    });
   });
 
   async function getLog(job_id: string) {

--- a/modules/shared/src/issue-parser.ts
+++ b/modules/shared/src/issue-parser.ts
@@ -30,7 +30,7 @@ function getHeadingContent(tree: Node, test: string) {
 // copied from Fiddle code
 export function getGistId(input: string): string | null {
   let id: string | undefined = input;
-  if (input.startsWith('https://gist.github.com')) {
+  if (input.startsWith('https://gist.github.com/')) {
     if (input.endsWith('/')) {
       input = input.slice(0, -1);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,6 +943,11 @@
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
   integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
 
+"@types/escape-html@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/escape-html/-/escape-html-1.0.1.tgz#b19b4646915f0ae2c306bf984dc0a59c5cfc97ba"
+  integrity sha512-4mI1FuUUZiuT95fSVqvZxp/ssQK9zsa86S43h9x3zPOSU9BBJ+BfDkXwuaU7BfsD+e7U0/cUUfJFk3iW2M4okA==
+
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.21.tgz#a427278e106bca77b83ad85221eae709a3414d42"
@@ -2330,7 +2335,7 @@ escape-goat@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-2.1.1.tgz#1b2dc77003676c457ec760b2dc68edb648188675"
   integrity sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
 
-escape-html@~1.0.3:
+escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=


### PR DESCRIPTION
This PR tries to address [a few warnings](https://lgtm.com/projects/g/electron/bugbot/?mode=list) that LGTM found in our codebase, the primary one being that we didn't sanitize the data that was passing into express' Response.send() calls.

- before calling expresss.Response.send(), filter the data through escapeHtml()
- remove a redundant regex char in the log matching code
- replace an inefficient regex when extracting the job id from `/api/jobs/${id}/log`
- try to avoid some gotchas in matching a gist.github.com URL

Also, while on the subject... any opinions on whether it would be useful to add LGTM to the Actions for sniffing PRs?