### PR TITLE
feat(broker): add PORT as env variable fallback

### DIFF
--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as http from 'http';
 import * as https from 'https';
 import * as jsonpatch from 'fast-json-patch';

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -7,7 +7,7 @@ import create_etag from 'etag';
 import express from 'express';
 import { URL } from 'url';
 
-import { env, envInt, getEnvData } from '@electron/bugbot-shared/lib/env-vars';
+import { env, getEnvData } from '@electron/bugbot-shared/lib/env-vars';
 
 import { Broker } from './broker';
 import { Task } from './task';
@@ -28,7 +28,6 @@ export class Server {
   private readonly broker: Broker;
   private readonly cert: string;
   private readonly key: string;
-  private readonly port: number;
   private server: http.Server;
 
   constructor(
@@ -41,7 +40,12 @@ export class Server {
   ) {
     this.broker = opts.broker || new Broker();
     this.brokerUrl = new URL(opts.brokerUrl || env('BUGBOT_BROKER_URL'));
-    this.port = Number.parseInt(this.brokerUrl.port, 10) || envInt('PORT');
+
+    // For Heroku, the $PORT env var is set dynamically
+    if (!this.brokerUrl.port) {
+      this.brokerUrl.port = env('PORT');
+    }
+
     if (this.brokerUrl.protocol === 'https:') {
       this.cert = opts.cert || getEnvData('BUGBOT_BROKER_CERT');
       this.key = opts.key || getEnvData('BUGBOT_BROKER_KEY');
@@ -182,19 +186,20 @@ export class Server {
       });
     };
 
+    const port = Number.parseInt(this.brokerUrl.port, 10);
     d(`url.protocol ${this.brokerUrl.protocol}`);
     switch (this.brokerUrl.protocol) {
       case 'http:': {
         const opts = {};
         this.server = http.createServer(opts, this.app);
-        return listen(this.server, this.port);
+        return listen(this.server, port);
       }
 
       case 'https:': {
         const { cert, key } = this;
         const opts = { cert, key };
         this.server = https.createServer(opts, this.app);
-        return listen(this.server, this.port);
+        return listen(this.server, port);
       }
 
       default: {

--- a/modules/broker/test/broker.spec.ts
+++ b/modules/broker/test/broker.spec.ts
@@ -60,14 +60,15 @@ describe('broker', () => {
   });
 
   it('uses environmental variables as a fallback', async () => {
-    const broker_url = new URL('https://localhost');
     process.env.PORT = '9229';
-    process.env.BUGBOT_BROKER_URL = broker_url.toString();
+    process.env.BUGBOT_BROKER_URL = 'https://localhost';
     process.env.BUGBOT_BROKER_CERT_PATH = fixturePath('test.cert');
     process.env.BUGBOT_BROKER_KEY_PATH = fixturePath('test.key');
 
     const https_server = new Server();
-    expect(https_server.brokerUrl).toStrictEqual(broker_url);
+    expect(https_server.brokerUrl).toStrictEqual(
+      new URL(`${process.env.BUGBOT_BROKER_URL}:${process.env.PORT}`),
+    );
     await expect(https_server.start()).resolves.not.toThrow();
     https_server.stop();
 

--- a/modules/broker/test/broker.spec.ts
+++ b/modules/broker/test/broker.spec.ts
@@ -60,7 +60,8 @@ describe('broker', () => {
   });
 
   it('uses environmental variables as a fallback', async () => {
-    const broker_url = new URL('https://localhost:9229');
+    const broker_url = new URL('https://localhost');
+    process.env.PORT = '9229';
     process.env.BUGBOT_BROKER_URL = broker_url.toString();
     process.env.BUGBOT_BROKER_CERT_PATH = fixturePath('test.cert');
     process.env.BUGBOT_BROKER_KEY_PATH = fixturePath('test.key');
@@ -70,6 +71,7 @@ describe('broker', () => {
     await expect(https_server.start()).resolves.not.toThrow();
     https_server.stop();
 
+    delete process.env.PORT;
     delete process.env.BUGBOT_BROKER_URL;
     delete process.env.BUGBOT_BROKER_CERT_PATH;
     delete process.env.BUGBOT_BROKER_KEY_PATH;


### PR DESCRIPTION
In preparation for deploying the broker to Heroku, this PR adds a `$PORT` environment variable fallback for the express server.

Each Heroku web process must bind to a port specified by the `$PORT` environment variable, which is assigned by Heroku itself when a dyno is spun up. See Heroku's [Runtime Principles](https://devcenter.heroku.com/articles/runtime-principles#web-servers) doc for more information.