### PR TITLE
feat: allow multiple args in BUGBOT_FIDDLE_EXEC env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ $ yarn run build
 | `BUGBOT_BROKER_KEY` or `BUGBOT_BROKER_KEY_PATH` | Required by Broker if `BUGBOT_BROKER_URL` is https | The data (or the path to it) to use as the `key` option to [https.createServer()](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener). | None |
 | `BUGBOT_BROKER_URL` | Required by all | The base URL for the broker, e.g. `https://bugbot.electronjs.org:8443`. | None |
 | `BUGBOT_CHILD_TIMEOUT_MS` | Runner | When to cancel a hung child | 5 minutes |
-| `BUGBOT_FIDDLE_EXEC` | Runner | Used to invoke electron-fiddle | '[which](https://github.com/npm/node-which) electron-fiddle' |
+| `BUGBOT_FIDDLE_EXEC` | Runner | Used to invoke electron-fiddle. This can include other space-delimited command-line arguments, e.g. `xvfb-run electron-fiddle` | '[which](https://github.com/npm/node-which) electron-fiddle' |
 | `BUGBOT_POLL_INTERVAL_MS` | Bot, Runner | How frequently to poll the Broker | 20 seconds |
 

--- a/modules/runner/package.json
+++ b/modules/runner/package.json
@@ -13,6 +13,7 @@
     "@electron/bugbot-shared": "*",
     "debug": "^4.3.1",
     "node-fetch": "^2.6.1",
+    "string-argv": "^0.3.1",
     "uuid": "^8.3.2",
     "which": "^2.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5636,6 +5636,11 @@ static-extend@^0.1.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+string-argv@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
 string-length@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"


### PR DESCRIPTION
This is needed when `electron-fiddle` is only part of the invocation, e.g. when invoking headless on Linux with `xvfb-run electron-fiddle`.