### PR TITLE
feat: batch up electron-fiddle to send to broker

### DIFF
--- a/integration-tests/test/broker-runner.test.ts
+++ b/integration-tests/test/broker-runner.test.ts
@@ -34,7 +34,7 @@ describe('runner', () => {
     runner = new Runner({
       brokerUrl,
       fiddleExec: path.resolve(__dirname, 'fixtures', 'electron-fiddle'),
-      logIntervalMs: 1,
+      logIntervalMs: 1, // minimize batching to avoid timing issues during testing
       platform,
       ...opts,
     });

--- a/integration-tests/test/broker-runner.test.ts
+++ b/integration-tests/test/broker-runner.test.ts
@@ -34,6 +34,7 @@ describe('runner', () => {
     runner = new Runner({
       brokerUrl,
       fiddleExec: path.resolve(__dirname, 'fixtures', 'electron-fiddle'),
+      logIntervalMs: 1,
       platform,
       ...opts,
     });

--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -36,6 +36,8 @@ export class Runner {
   private etag: string;
   private interval: ReturnType<typeof setInterval>;
   private jobId: JobId;
+  private putLogBuf: string[] = [];
+  private putLogTimer: ReturnType<typeof setTimeout>;
   private timeBegun: number;
 
   /**
@@ -181,10 +183,6 @@ export class Runner {
 
     this.etag = etag;
   }
-
-  private putLogTimer: ReturnType<typeof setTimeout>;
-
-  private putLogBuf: string[] = [];
 
   private putLog(data: any) {
     // save the URL to safeguard against this.jobId being cleared at end-of-job

--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -187,8 +187,9 @@ export class Runner {
   private async putLogImpl(url: URL) {
     delete this.putLogTimer;
 
-    const body = this.putLogBuf.splice(0).join('\n');
-    d(`putLogImpl sending ${body.split('\n').length} lines`, body);
+    const lines = this.putLogBuf.splice(0);
+    const body = lines.join('\n');
+    d(`putLogImpl sending ${lines.length} lines`, body);
     const resp = await fetch(url, {
       body,
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },

--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -183,13 +183,14 @@ export class Runner {
   private putLogBuf: string[] = [];
 
   private putLog(data: any) {
+    // save the URL to safeguard against this.jobId being cleared at end-of-job
+    const log_url = new URL(`api/jobs/${this.jobId}/log`, this.brokerUrl);
     this.putLogBuf.push(data);
     this.putLogTimer ||= setTimeout(async () => {
       const body = this.putLogBuf.splice(0).join('\n');
       delete this.putLogTimer;
 
       d('putLog', body);
-      const log_url = new URL(`api/jobs/${this.jobId}/log`, this.brokerUrl);
       const resp = await fetch(log_url, {
         body,
         headers: { 'Content-Type': 'text/plain; charset=utf-8' },


### PR DESCRIPTION
Right now the runner contacts the broker every single time there's a line of log data to append from electron-fiddle.

This PR adds a debounce timer to batch them up and reduce the number of round trips needed.

The current interval is 2 seconds. This is configurable via the Runner constructor opts object so that tests don't have to wait that long. I don't see a use case for end users so I didn't add an environment variable, but I don't mind adding it if someone else sees a use for it.