### PR TITLE
build: add 'tsc' to package.json's scripts

### DIFF
--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -3,10 +3,13 @@
   "compilerOptions": {
     "outDir": "dist",
     "tsBuildInfoFile": "dist/.tsbuildinfo",
-    "rootDir": "src",
+    "rootDir": "src"
   },
   "include": ["src/**/*"],
   "references": [
-    { "path": "../shared" }
+    { "path": "../modules/bot" },
+    { "path": "../modules/broker" },
+    { "path": "../modules/runner" },
+    { "path": "../modules/shared" }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:eslint:fix": "eslint --fix modules/*/src/**/*.ts",
     "lint:prettier": "prettier --check package.json modules/*/package.json modules/*/src/**/*.ts",
     "lint:prettier:fix": "prettier --write package.json modules/*/package.json modules/*/src/**/*.ts",
-    "heroku-postbuild": "yarn build"
+    "heroku-postbuild": "yarn build",
+    "tsc": "yarn workspaces run tsc"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.24.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:prettier": "prettier --check package.json modules/*/package.json modules/*/src/**/*.ts",
     "lint:prettier:fix": "prettier --write package.json modules/*/package.json modules/*/src/**/*.ts",
     "heroku-postbuild": "yarn build",
-    "tsc": "yarn workspaces run tsc"
+    "typecheck": "yarn workspaces run tsc --noEmit"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.24.0",


### PR DESCRIPTION
Pretty straightforward. It calls 'tsc' on all the submodules.

Also fixes the references in integration-tests, since running `yarn tsc` uncovered a broken path there.