### PR TITLE
fix: include `/test/` folder in `tsconfig.json`

### DIFF
--- a/modules/bot/tsconfig.json
+++ b/modules/bot/tsconfig.json
@@ -5,7 +5,7 @@
     "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "src",
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "references": [
     { "path": "../shared" },
     { "path": "../runner" },

--- a/modules/broker/tsconfig.json
+++ b/modules/broker/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": "src",
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "references": [
     { "path": "../shared" }
   ]

--- a/modules/runner/tsconfig.json
+++ b/modules/runner/tsconfig.json
@@ -5,7 +5,7 @@
     "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "src"
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "references": [
     { "path": "../shared" }
   ]

--- a/modules/shared/tsconfig.json
+++ b/modules/shared/tsconfig.json
@@ -5,5 +5,5 @@
     "tsBuildInfoFile": "lib/.tsbuildinfo",
     "rootDir": "src"
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
Our various test folders are called `/test/`, but #80 called them `/tests/` instead.