### PR TITLE
fix: define `engines` in global `package.json`

### DIFF
--- a/modules/broker/package.json
+++ b/modules/broker/package.json
@@ -23,8 +23,5 @@
   },
   "devDependencies": {
     "@types/escape-html": "^1.0.1"
-  },
-  "engines": {
-    "node": ">=16.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.0",
     "typescript": "^4.2.4"
+  },
+  "engines": {
+    "node": ">=16.0.0"
   }
 }


### PR DESCRIPTION
Heroku's workspace support isn't great, and it looks like our latest build failed because their Node.js buildpack loaded the LTS version of Node.js.

```
error @electron/bugbot-broker@0.0.1: The engine "node" is incompatible with this module. Expected version ">=16.0.0". Got "14.17.2"
error Commands cannot run with an incompatible environment.
       info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
```

This PR moves the `engines` check to the global `package.json` so that Heroku can detect that we need Node 16.