### PR TITLE
test: include integration tests in test coverage

### DIFF
--- a/integration-tests/jest.config.js
+++ b/integration-tests/jest.config.js
@@ -2,8 +2,8 @@ process.env.SPEC_RUNNING = '1';
 
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   preset: 'ts-jest',
-  roots: ['<rootDir>/test'],
-  testRegex: '(/spec/.*|(\\.|/)(test|spec))\\.tsx?$',
+  rootDir: `${__dirname}/..`,
+  roots: [`${__dirname}/test`],
+  testMatch: ['**/*.(spec|test).ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,16 +2,11 @@ process.env.SPEC_RUNNING = '1';
 
 module.exports = {
   clearMocks: true,
-  collectCoverageFrom: ['**/src/**/*ts'],
-  coveragePathIgnorePatterns: ['/node_modules/', '/lib/'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  collectCoverageFrom: ['<rootDir>/modules/*/src/**/*ts'],
+  coverageDirectory: '<rootDir>/coverage/',
   preset: 'ts-jest',
   projects: [
+    '<rootDir>/modules/*/',
     '<rootDir>/integration-tests',
-    '<rootDir>/modules/bot',
-    '<rootDir>/modules/broker',
-    '<rootDir>/modules/runner',
-    '<rootDir>/modules/shared',
   ],
-  testRegex: '(/spec/.*|(\\.|/)(test|spec))\\.tsx?$',
 };

--- a/modules/bot/jest.config.js
+++ b/modules/bot/jest.config.js
@@ -2,8 +2,8 @@ process.env.SPEC_RUNNING = '1';
 
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   preset: 'ts-jest',
-  roots: ['<rootDir>/test'],
-  testRegex: '(/spec/.*|(\\.|/)(test|spec))\\.tsx?$',
+  rootDir: `${__dirname}/../..`,
+  roots: [`${__dirname}/test`],
+  testMatch: ['**/*.(spec|test).ts'],
 };

--- a/modules/broker/jest.config.js
+++ b/modules/broker/jest.config.js
@@ -2,8 +2,8 @@ process.env.SPEC_RUNNING = '1';
 
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   preset: 'ts-jest',
-  roots: ['<rootDir>/test'],
-  testRegex: '(/spec/.*|(\\.|/)(test|spec))\\.tsx?$',
+  rootDir: `${__dirname}/../..`,
+  roots: [`${__dirname}/test`],
+  testMatch: ['**/*.(spec|test).ts'],
 };

--- a/modules/runner/jest.config.js
+++ b/modules/runner/jest.config.js
@@ -2,8 +2,8 @@ process.env.SPEC_RUNNING = '1';
 
 module.exports = {
   clearMocks: true,
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   preset: 'ts-jest',
-  roots: ['<rootDir>/test'],
-  testRegex: '(/spec/.*|(\\.|/)(test|spec))\\.tsx?$',
+  rootDir: `${__dirname}/../..`,
+  roots: [`${__dirname}/test`],
+  testMatch: ['**/*.(spec|test).ts'],
 };

--- a/modules/shared/jest.config.js
+++ b/modules/shared/jest.config.js
@@ -2,9 +2,8 @@ process.env.SPEC_RUNNING = '1';
 
 module.exports = {
   clearMocks: true,
-  coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/modules/*/lib'],
-  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   preset: 'ts-jest',
-  roots: ['<rootDir>/test'],
-  testRegex: '(/spec/.*|(\\.|/)(test|spec))\\.tsx?$',
+  rootDir: `${__dirname}/../..`,
+  roots: [`${__dirname}/test`],
+  testMatch: ['**/*.(spec|test).ts'],
 };


### PR DESCRIPTION
Does what it says on the tin. Based on [this stackoverflow](https://stackoverflow.com/questions/60347361/jest-projects-in-a-monorepo-unable-to-find-config-files-in-projects) pointer about pointing the modules' `rootDir` at the top-level project. Remove  config settings that have no effect.

*edit:* This lowers coverage slightly because `modules/runner/runner.ts` is now included in the reports.