### PR TITLE
chore: ignore config files in eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ const config = {
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:prettier/recommended'
   ],
+  ignorePatterns: ['.eslintrc.js', 'jest.config.js'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
After #80, navigating to a config JS file in the root folder gives the following ESLint error:

```
Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: .eslintrc.js.
The file must be included in at least one of the projects provided.
```

This PR adds the ESLint and Jest configs to the ESLint ignore patterns.