### PR TITLE
fix: unlikely but possible infinite versions loop

### DIFF
--- a/modules/bot/src/electron-versions.ts
+++ b/modules/bot/src/electron-versions.ts
@@ -63,7 +63,7 @@ export class ElectronVersions {
     const UNSUPPORTED_MAJORS_TO_TEST = 2;
     const NUM_STABLE_TO_TEST = SUPPORTED_MAJORS + UNSUPPORTED_MAJORS_TO_TEST;
     let stableLeft = NUM_STABLE_TO_TEST;
-    while (stableLeft > 0) {
+    while (majors.length > 0 && stableLeft > 0) {
       const major = majors.pop();
       let range = byMajor.get(major);
       if (hasStable(range)) {


### PR DESCRIPTION
If we somehow got an incomplete list of Electron releases from the CDN, it's just possible that bugbot could freeze up in an infinite loop because of a bug in some new code that I wrote.

The preconditions to tickle this bug are very unlikely, but this PR fixes it anyway.