### PR TITLE
feat(bot): self-update bot comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ $ yarn run build
 | `BUGBOT_FIDDLE_EXEC` | Runner | Used to invoke electron-fiddle. This can include other space-delimited command-line arguments, e.g. `xvfb-run electron-fiddle` | '[which](https://github.com/npm/node-which) electron-fiddle' |
 | `BUGBOT_POLL_INTERVAL_MS` | Bot, Runner | How frequently to poll the Broker | 20 seconds |
 | `BUGBOT_AUTH_TOKEN` | Bot, Runner | The auth token for communications with the Broker |
+| `BUGBOT_GITHUB_LOGIN` | Bot | The name of the GitHub app registered for the Probot client |

--- a/modules/bot/package.json
+++ b/modules/bot/package.json
@@ -30,7 +30,6 @@
     "@types/unist": "^2.0.3",
     "jest": "^26.6.3",
     "nock": "^13.0.11",
-    "smee-client": "^1.2.2",
-    "type-fest": "^1.2.1"
+    "smee-client": "^1.2.2"
   }
 }

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -125,12 +125,11 @@ export class GithubClient {
       try {
         input = parseIssueBody(body);
         d(`parseIssueBody returned ${JSON.stringify(input)}`);
+        await this.runBisectJob(input, context);
       } catch (e) {
-        d('Unable to parse issue body for bisect', e);
+        d('Unable to run bisect job', e);
         return;
       }
-
-      await this.runBisectJob(input, context);
     }
   }
 
@@ -177,7 +176,7 @@ export class GithubClient {
             await this.handleBisectResult(jobId, job.last, context);
             await this.broker.completeJob(jobId);
           } catch (e) {
-            reject(e);
+            return reject(e);
           }
           return resolve();
         }

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -274,7 +274,7 @@ export class GithubClient {
 
     const lastBotComment = comments.reverse().find((comment) => {
       const { user } = comment;
-      const botName = env('BUGBOT_BOT_NAME');
+      const botName = env('BUGBOT_GITHUB_LOGIN');
       return user.login === `${botName}[bot]`;
     });
 

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -90,7 +90,7 @@ export class GithubClient {
   private async handleManualCommand(
     context: Context<'issue_comment'>,
   ): Promise<void> {
-    const d = debug('GitHubClient:handleManualCommand');
+    const d = debug('GithubClient:handleManualCommand');
 
     const { payload } = context;
     const args = payload.comment.body.split(' ');
@@ -138,9 +138,9 @@ export class GithubClient {
     input: FiddleInput,
     context: Context<'issue_comment'>,
   ) {
-    const d = debug('GitHubClient:runBisectJob');
+    const d = debug('GithubClient:runBisectJob');
 
-    d(`Updating GitHub issue #${context.payload.issue.id}`);
+    d(`Updating GitHub issue id ${context.payload.issue.id}`);
     const promises: Promise<unknown>[] = [];
     promises.push(this.setIssueComment('Queuing bisect job...', context));
     promises.push(
@@ -157,6 +157,7 @@ export class GithubClient {
     // FIXME: this state info, such as the timer, needs to be a
     // class property so that '/test stop' could stop the polling.
     // Poll until the job is complete
+    d(`Polling every ${this.pollIntervalMs}ms`);
     const timer = setInterval(async () => {
       if (this.isClosed) return clearInterval(timer);
       d(`polling job ${jobId}...`);

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -141,7 +141,7 @@ describe('github-client', () => {
       });
     });
 
-    describe('commentBisectResult()', () => {
+    describe('handleBisectResult()', () => {
       beforeEach(() => {
         nock.disableNetConnect();
       });

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -1,5 +1,5 @@
 process.env.BUGBOT_BROKER_URL = 'http://localhost:9099';
-process.env.BUGBOT_BOT_NAME = 'erick-bugbot';
+process.env.BUGBOT_GITHUB_LOGIN = 'erick-bugbot';
 process.env.BUGBOT_AUTH_TOKEN = 'fake_token';
 
 import nock from 'nock';
@@ -122,7 +122,10 @@ describe('github-client', () => {
           // Now, the comment from above should exist...
           .get('/repos/erickzhao/bugbot/issues/10/comments?per_page=100')
           .reply(200, [
-            { id: 1, user: { login: `${process.env.BUGBOT_BOT_NAME}[bot]` } },
+            {
+              id: 1,
+              user: { login: `${process.env.BUGBOT_GITHUB_LOGIN}[bot]` },
+            },
           ])
 
           // ...so we update it with the bisect info.
@@ -201,7 +204,10 @@ describe('github-client', () => {
           // Now, the comment from above should exist...
           .get('/repos/erickzhao/bugbot/issues/10/comments?per_page=100')
           .reply(200, [
-            { id: 1, user: { login: `${process.env.BUGBOT_BOT_NAME}[bot]` } },
+            {
+              id: 1,
+              user: { login: `${process.env.BUGBOT_GITHUB_LOGIN}[bot]` },
+            },
           ])
           // ...so we update the comment with an error message.
           .patch('/repos/erickzhao/bugbot/issues/comments/1', ({ body }) => {

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -64,7 +64,9 @@ describe('github-client', () => {
   afterEach(() => {
     ghclient.close();
 
-    console.log('isDone:', nock.isDone());
+    if (!nock.isDone()) {
+      throw new Error(`Unused nock interceptors: "${expect.getState().currentTestName}"`)
+    }
 
     nock.cleanAll();
     nock.enableNetConnect();
@@ -211,9 +213,11 @@ describe('github-client', () => {
             payload: payloadFixture,
           } as any);
 
+          expect(mockCompleteJob).toHaveBeenCalledWith('my-job-id');
+
         });
 
-        it.only('handles failures gracefully', async (done) => {
+        it('handles failures gracefully', async () => {
           const mockTestError: Result = {
             error: 'my-error',
             runner: 'my-runner-id',
@@ -263,7 +267,6 @@ describe('github-client', () => {
                   'A maintainer in @wg-releases will need to look into this. When any issues are resolved, BugBot can be restarted by replacing the bugbot/maintainer-needed label with bugbot/test-needed.\n\n' +
                   `For more information, see ${brokerBaseUrl}/log/${mockJob.id}`,
               );
-              done();
               return true;
             })
             .reply(200)
@@ -287,7 +290,7 @@ describe('github-client', () => {
             payload: payloadFixture,
           } as any);
 
-          expect(mockCompleteJob).not.toHaveBeenCalled();
+          expect(mockCompleteJob).toHaveBeenCalledWith('my-job-id');
         });
       });
     });

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -141,9 +141,7 @@ describe('github-client', () => {
           // delete the `bugbot/test-running` label and add `bug/regression`
           .delete(
             '/repos/erickzhao/bugbot/issues/10/labels/bugbot%2Ftest-running',
-            () => {
-              return true;
-            },
+            () => true,
           )
           .reply(200)
           .post('/repos/erickzhao/bugbot/issues/10/labels', ({ labels }) => {
@@ -219,9 +217,7 @@ describe('github-client', () => {
           // delete the `bugbot/test-running` label and add `bugbot/maintainer-needed`
           .delete(
             '/repos/erickzhao/bugbot/issues/10/labels/bugbot%2Ftest-running',
-            () => {
-              return true;
-            },
+            () => true,
           )
           .reply(200)
           .post('/repos/erickzhao/bugbot/issues/10/labels', ({ labels }) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6017,11 +6017,6 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-fest@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.2.1.tgz#232990aa513f3f5223abf54363975dfe3a121a2e"
-  integrity sha512-SbmIRuXhJs8KTneu77Ecylt9zuqL683tuiLYpTRil4H++eIhqCmx6ko6KAFem9dty8sOdnEiX7j4K1nRE628fQ==
-
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"


### PR DESCRIPTION
Closes #97.

The base logic here is in the `setIssueComment` function, which takes in a Probot context and a string for the comment body.

It was a pain to test these changes with the test infrastructure set up in #91, so I had to refactor a bunch of things.

In the client's source code:
* The polling logic is now in a recursive `setTimeout` that resolves a Promise when the job is done. This improves our previous `setInterval` implementation, which actually failed when if the timer's interval was too low (see [ESLint rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-misused-promises.md)).
* The code is broken up into more modular pieces (a new intermediary `runBisectJob` is added) and function names are changed to be more accurate (`parseManualCommand` -> `handleManualCommand`, `commentBisectResult` -> `handleBisectResult`).

In the tests:
* All tests in the suite now use `fixtures/issue_comment.created.json` for uniformity.
* Nock is initialized for all tests in the suite.
* Cleaned up the `describe` hierarchy.