### PR TITLE
feat: use explicit token passed to broker in env

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ $ yarn run build
 | `BUGBOT_CHILD_TIMEOUT_MS` | Runner | When to cancel a hung child | 5 minutes |
 | `BUGBOT_FIDDLE_EXEC` | Runner | Used to invoke electron-fiddle. This can include other space-delimited command-line arguments, e.g. `xvfb-run electron-fiddle` | '[which](https://github.com/npm/node-which) electron-fiddle' |
 | `BUGBOT_POLL_INTERVAL_MS` | Bot, Runner | How frequently to poll the Broker | 20 seconds |
-| `BUGBOT_AUTH_TOKEN` | Bot, Runner | The auth token for communications with the Broker |
+| `BUGBOT_AUTH_TOKEN` | Required: Bot, Runner; Optional: Broker | The auth token for communications with the Broker |
 | `BUGBOT_GITHUB_LOGIN` | Bot | The name of the GitHub app registered for the Probot client |

--- a/modules/broker/src/auth.ts
+++ b/modules/broker/src/auth.ts
@@ -20,7 +20,18 @@ export enum AuthScope {
 
   /** Ability to update existing jobs. */
   UpdateJobs = 'jobs:update',
+
+  // NOTE: when adding more scopes, make sure to include them in the
+  // `ALL_SCOPES` array below.
 }
+
+// TODO: perhaps having a "glob" matching system would help, e.g. `jobs:*` or
+// simply `*`
+export const ALL_SCOPES = [
+  AuthScope.ControlTokens,
+  AuthScope.CreateJobs,
+  AuthScope.UpdateJobs,
+];
 
 /**
  * Data about an authorization through the security layer.
@@ -47,9 +58,9 @@ export class Auth {
    * Generates a new auth data object with the supplied scopes, adds it to the
    * token store, then returns the token.
    */
-  public createToken(scopes: AuthScope[]): string {
-    // Generate a token
-    const token = randomToken();
+  public createToken(scopes: AuthScope[], authToken?: string): string {
+    // Use the given token or generate one
+    const token = authToken ?? randomToken();
 
     // Add a token object to the token store
     this.tokens.set(token, {

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -9,7 +9,7 @@ import { URL } from 'url';
 
 import { env, getEnvData } from '@electron/bugbot-shared/build/env-vars';
 
-import { Auth, AuthScope } from './auth';
+import { ALL_SCOPES, Auth, AuthScope } from './auth';
 import { Broker } from './broker';
 import { Task } from './task';
 import { buildLog } from './log';
@@ -56,10 +56,16 @@ export class Server {
       this.key = opts.key || getEnvData('BUGBOT_BROKER_KEY');
     }
 
-    // Initialize auth either from being passed in or by creating a new auth
-    // with a control token that is printed out
+    // Initialize auth from being passed in as an object, as an environment
+    // variable, or by creating a new auth with a control token that is printed
+    // out
     if (opts.auth !== undefined) {
       this.auth = opts.auth;
+    } else if (process.env.BUGBOT_AUTH_TOKEN !== undefined) {
+      this.auth = new Auth();
+
+      // Create a token with all scopes using the environment value
+      this.auth.createToken(ALL_SCOPES, process.env.BUGBOT_AUTH_TOKEN);
     } else {
       this.auth = new Auth();
 

--- a/modules/broker/test/auth.spec.ts
+++ b/modules/broker/test/auth.spec.ts
@@ -14,6 +14,13 @@ describe('auth', () => {
     expect(auth.tokenHasScopes(tokenId, [])).toBe(true);
   });
 
+  it('uses given token values', () => {
+    const TOKEN = 'my super real token';
+    const auth = new Auth();
+    auth.createToken([], TOKEN);
+    expect(auth.tokenHasScopes(TOKEN, [])).toBe(true);
+  });
+
   it('fails to revoke unknown tokens', () => {
     const auth = new Auth();
     expect(auth.revokeToken(FAKE_TOKEN)).toBe(false);

--- a/modules/broker/test/broker.spec.ts
+++ b/modules/broker/test/broker.spec.ts
@@ -104,6 +104,7 @@ describe('broker', () => {
     process.env.BUGBOT_BROKER_URL = 'https://localhost';
     process.env.BUGBOT_BROKER_CERT_PATH = fixturePath('test.cert');
     process.env.BUGBOT_BROKER_KEY_PATH = fixturePath('test.key');
+    process.env.BUGBOT_AUTH_TOKEN = 'test';
 
     const https_server = new Server();
     expect(https_server.brokerUrl).toStrictEqual(
@@ -116,6 +117,7 @@ describe('broker', () => {
     delete process.env.BUGBOT_BROKER_URL;
     delete process.env.BUGBOT_BROKER_CERT_PATH;
     delete process.env.BUGBOT_BROKER_KEY_PATH;
+    delete process.env.BUGBOT_AUTH_TOKEN;
   });
 
   async function postNewBisectJob(params = {}) {


### PR DESCRIPTION
Allows the broker to use a `BUGBOT_AUTH_TOKEN` environment variable if one is present, granting that token value access to all scopes.

Fixes #111.