### PR TITLE
feat(bot): only allow commands for maintainers

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -61,10 +61,18 @@ export class GithubClient {
     this.robot.on('issue_comment.edited', (ctx) => this.onIssueComment(ctx));
   }
 
-  private static isMaintainer(login: string): Promise<boolean> {
-    // TODO(erickzhao): add allowlist here
-    const maintainers = ['ckerr', 'clavin', 'erickzhao'];
-    return Promise.resolve(maintainers.includes(login));
+  // from https://github.com/electron/trop/blob/master/src/utils.ts
+  private async isAuthorizedUser(
+    context: Context<'issue_comment'>,
+    username: string,
+  ) {
+    const { data } = await context.octokit.repos.getCollaboratorPermissionLevel(
+      context.repo({
+        username,
+      }),
+    );
+
+    return ['admin', 'write'].includes(data.permission);
   }
 
   public async onIssueComment(
@@ -74,8 +82,8 @@ export class GithubClient {
     d('===> payload <===', JSON.stringify(context.payload));
 
     const { login } = context.payload.comment.user;
-    if (!(await GithubClient.isMaintainer(login))) {
-      d('not a maintainer; doing nothing');
+    if (!(await this.isAuthorizedUser(context, login))) {
+      d(`"${login}" is not a maintainer — doing nothing`);
       return;
     }
 

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -2,7 +2,7 @@ process.env.BUGBOT_BROKER_URL = 'http://localhost:9099';
 process.env.BUGBOT_GITHUB_LOGIN = 'erick-bugbot';
 process.env.BUGBOT_AUTH_TOKEN = 'fake_token';
 
-import nock from 'nock';
+import nock, { Scope } from 'nock';
 import { createProbot, Probot, ProbotOctokit } from 'probot';
 
 import BrokerAPI from '../src/broker-client';
@@ -17,12 +17,14 @@ describe('github-client', () => {
   const authToken = process.env.BUGBOT_AUTH_TOKEN;
   const brokerBaseUrl = process.env.BUGBOT_BROKER_URL;
   const pollIntervalMs = 10;
+
   let ghclient: GithubClient;
   let mockCompleteJob: jest.Mock;
   let mockGetJob: jest.Mock;
   let mockQueueBisectJob: jest.Mock;
   let mockStopJob: jest.Mock;
   let robot: Probot;
+  let nockScope: Scope;
 
   beforeEach(() => {
     mockCompleteJob = jest.fn();
@@ -63,7 +65,9 @@ describe('github-client', () => {
 
     if (!nock.isDone()) {
       throw new Error(
-        `Unused nock interceptors: "${expect.getState().currentTestName}"`,
+        `Unused nock interceptors in test "${
+          expect.getState().currentTestName
+        }"\n ${JSON.stringify(nock.pendingMocks())}`,
       );
     }
 
@@ -73,6 +77,14 @@ describe('github-client', () => {
 
   describe('GithubClient', () => {
     describe('on `/test bisect` command', () => {
+      beforeEach(() => {
+        nockScope = nock('https://api.github.com');
+        nockScope
+          .get('/repos/erickzhao/bugbot/collaborators/erickzhao/permission')
+          .reply(200, {
+            permission: 'admin',
+          });
+      });
       it('queues a bisect job and comments the result', async () => {
         const mockSuccess: Result = {
           bisect_range: ['10.3.2', '10.4.0'],
@@ -100,7 +112,7 @@ describe('github-client', () => {
           .mockResolvedValueOnce(mockJobRunning)
           .mockResolvedValueOnce(mockJobDone);
 
-        nock('https://api.github.com')
+        nockScope
           // No comments yet...
           .get('/repos/erickzhao/bugbot/issues/10/comments?per_page=100')
           .reply(200, [])
@@ -182,7 +194,7 @@ describe('github-client', () => {
         mockQueueBisectJob.mockResolvedValueOnce(mockJob.id);
         mockGetJob.mockResolvedValueOnce(mockJob);
 
-        nock('https://api.github.com')
+        nockScope
           // No comments yet...
           .get('/repos/erickzhao/bugbot/issues/10/comments?per_page=100')
           .reply(200, [])
@@ -272,6 +284,18 @@ describe('github-client', () => {
         });
 
         it('...the commenter is not a maintainer', async () => {
+          // remove existing valid maintainer mock
+          const interceptor = nockScope.get(
+            '/repos/erickzhao/bugbot/collaborators/erickzhao/permission',
+          );
+          nock.removeInterceptor(interceptor);
+
+          // mock invalid maintainer
+          nockScope
+            .get('/repos/erickzhao/bugbot/collaborators/fnord/permission')
+            .reply(200, {
+              permissions: 'none',
+            });
           const onIssueCommentSpy = jest.spyOn(ghclient, 'onIssueComment');
           const unauthorizedUserFixture = JSON.parse(
             JSON.stringify(payloadFixture),


### PR DESCRIPTION
Closes #106.

Takes @ckerr's suggestion of borrowing the code snippet from `trop`. As a side effect, this means I won't have access to the `/test` command in production. 😅 

This PR also brings a couple more `nock` goodies.

* The unused interceptor validator now prints out which interceptors are remaining.
* Nock scope is instantiated in the `beforeEach()` of each test.