### PR TITLE
chore: add debug calls when new jobs are posted

### DIFF
--- a/modules/bot/src/broker-client.ts
+++ b/modules/bot/src/broker-client.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import fetch, { Response } from 'node-fetch';
 import { URL } from 'url';
 import { v4 as mkuuid } from 'uuid';
@@ -10,6 +11,8 @@ import {
 } from '@electron/bugbot-shared/build/interfaces';
 
 import { FiddleInput } from './issue-parser';
+
+const DebugPrefix = 'BrokerAPI';
 
 export class APIError extends Error {
   public res: Response;
@@ -30,7 +33,10 @@ export default class BrokerAPI {
   }
 
   public async queueBisectJob(fiddle: FiddleInput): Promise<string> {
+    const d = debug(`${DebugPrefix}:queueBisectJob`);
+
     const url = new URL('/api/jobs', this.baseURL);
+    d('url', url);
 
     const bisectJob: BisectJob = {
       bisect_range: [fiddle.goodVersion, fiddle.badVersion],
@@ -41,8 +47,10 @@ export default class BrokerAPI {
       type: 'bisect',
     };
 
-    const res = await fetch(url.toString(), {
-      body: JSON.stringify(bisectJob),
+    const body = JSON.stringify(bisectJob);
+    d('body', body);
+    const response = await fetch(url.toString(), {
+      body,
       headers: {
         Authorization: `Bearer ${this.authToken}`,
         'Content-Type': 'application/json',
@@ -50,27 +58,43 @@ export default class BrokerAPI {
       method: 'POST',
     });
 
-    return await res.text();
+    const { status, statusText } = response;
+    d('status', status, 'statusText', statusText);
+    const jobId = await response.text();
+    d('jobId', jobId);
+    return jobId;
   }
 
-  public stopJob(jobId: JobId): void {
+  public stopJob(jobId: JobId) {
     const url = new URL(`/api/jobs/${jobId}`, this.baseURL);
     console.log('stopping job', { url });
   }
 
   public async getJob(jobId: JobId): Promise<Job> {
+    const d = debug(`${DebugPrefix}:getJob`);
+
     const url = new URL(`/api/jobs/${jobId}`, this.baseURL);
-    const res = await fetch(url.toString(), {
+    d('url', url);
+
+    const response = await fetch(url.toString(), {
       headers: {
         Authorization: `Bearer ${this.authToken}`,
       },
     });
-    return res.json();
+
+    const { status, statusText } = response;
+    d('status', status, 'statusText', statusText);
+
+    return response.json();
   }
 
   public async completeJob(jobId: JobId): Promise<void> {
+    const d = debug(`${DebugPrefix}:completeJob`);
+
     const url = new URL(`/api/jobs/${jobId}`, this.baseURL);
-    await fetch(url.toString(), {
+    d('url', url);
+
+    const response = await fetch(url.toString(), {
       body: JSON.stringify([
         { op: 'replace', path: '/bot_client_data', value: 'complete' },
       ]),
@@ -80,5 +104,8 @@ export default class BrokerAPI {
       },
       method: 'PATCH',
     });
+
+    const { status, statusText } = response;
+    d('status', status, 'statusText', statusText);
   }
 }

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -142,12 +142,15 @@ export class Server {
   }
 
   private postJob(req: express.Request, res: express.Response) {
+    const d = debug(`${DebugPrefix}:postJob`);
+    d('posting job', req.body);
     try {
       assertJob(req.body);
       const task = new Task(req.body);
       this.broker.addTask(task);
       res.status(201).send(escapeHtml(task.job.id));
     } catch (error: unknown) {
+      d('bad job', error);
       res.status(422).send(escapeHtml(error.toString()));
     }
   }


### PR DESCRIPTION
The Heroku bot isn't successfully posting jobs to the broker, and it's not clear why.

This PR adds some tracer debug() calls to help triage this issue / future issues.