### PR TITLE
chore: increment number of supported branches to 4

### DIFF
--- a/modules/bot/src/electron-versions.ts
+++ b/modules/bot/src/electron-versions.ts
@@ -61,7 +61,9 @@ export class ElectronVersions {
 
     // Get the oldest and newest version of each branch we're testing.
     // If a branch has gone stable, skip its prereleases.
-    const SUPPORTED_MAJORS = 3; // https://www.electronjs.org/docs/tutorial/support
+
+    // const SUPPORTED_MAJORS = 3; // https://www.electronjs.org/docs/tutorial/support
+    const SUPPORTED_MAJORS = 4; // for rest of 2021. https://github.com/electron/electronjs.org/pull/5463
     const UNSUPPORTED_MAJORS_TO_TEST = 2;
     const NUM_STABLE_TO_TEST = SUPPORTED_MAJORS + UNSUPPORTED_MAJORS_TO_TEST;
     let stableLeft = NUM_STABLE_TO_TEST;

--- a/modules/bot/test/electron-versions.spec.ts
+++ b/modules/bot/test/electron-versions.spec.ts
@@ -22,18 +22,20 @@ describe('electron-versions', () => {
   it.each([
     ['sorted', 'gets-the-supported-versions.json'],
     ['unsorted', 'gets-the-supported-versions-unsorted.json'],
-  ])('gets the supported versions when lite.json is %s', async (name, filename) => {
+  ])('gets the supported versions when data is %s', async (name, filename) => {
     mockFetch(filename);
     const electronVersions = new ElectronVersions();
     const versions = await electronVersions.getVersionsToTest();
     expect(versions).toStrictEqual([
       // two unsupported old versions
+      '8.0.0',
+      '8.5.5',
       '9.0.0',
       '9.4.4',
+
+      // four currently-supported versions
       '10.0.0',
       '10.4.7',
-
-      // all currently-supported versions
       '11.0.0',
       '11.4.9',
       '12.0.0',
@@ -55,12 +57,14 @@ describe('electron-versions', () => {
     const versions = await electronVersions.getVersionsToTest();
     expect(versions).toStrictEqual([
       // two unsupported old versions
+      '8.0.0',
+      '8.5.5',
       '9.0.0',
       '9.4.4',
+
+      // four currently-supported versions
       '10.0.0',
       '10.4.7',
-
-      // all currently-supported versions
       '11.0.0',
       '11.4.9',
       '12.0.0',


### PR DESCRIPTION
Increase the number of supported branches to four as per https://github.com/electron/electronjs.org/pull/5463