### PR TITLE
refactor(bot): move polling logic into helper func

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -105,6 +105,8 @@ export class GithubClient {
         line,
         this.versions,
       );
+
+      // TODO(any): add 'stop' command
       if (cmd?.type === JobType.bisect) {
         promises.push(this.runBisectJob(cmd, context));
       }
@@ -165,20 +167,6 @@ export class GithubClient {
       setTimeout(pollBroker, this.pollIntervalMs);
     });
   }
-
-  /*
-   * FIXME: this draft implementation needs to be completed
-   * const id = 'some-guid';
-   * let currentJob;
-   * try {
-   *   currentJob = await this.broker.getJob(id);
-   * } catch (e) {
-   *    // no-op
-   * }
-   * if (action === actions.STOP && currentJob && !currentJob.time_finished) {
-   *   this.broker.stopJob(id);
-   * } else if (action === actions.BISECT && !currentJob) {
-   */
 
   /**
    * Comments on the issue once a bisect operation is completed

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -136,8 +136,14 @@ export class GithubClient {
     const jobId = await this.broker.queueBisectJob(bisectCmd);
     d(`Queued bisect job ${jobId}`);
 
-    const result = await this.pollAndReturnJob(jobId);
-    if (result) await this.handleBisectResult(result.id, result.last, context);
+    const completedJob = await this.pollAndReturnJob(jobId);
+    if (completedJob) {
+      await this.handleBisectResult(
+        completedJob.id,
+        completedJob.last,
+        context,
+      );
+    }
   }
 
   private async pollAndReturnJob(jobId: JobId) {


### PR DESCRIPTION
In preparation for #102, this makes the broker polling logic reusable to accommodate for more use-cases.

I didn't test this in production, but the existing unit tests passed without fail.