### PR TITLE
fix: runner polling loop

### DIFF
--- a/integration-tests/test/broker-runner.test.ts
+++ b/integration-tests/test/broker-runner.test.ts
@@ -65,7 +65,7 @@ describe('runner', () => {
     await startBroker();
     broker.addTask(task);
     createRunner(runnerOpts);
-    await runner.poll();
+    await runner.pollOnce();
   }
 
   function createBisectTask(job: Partial<BisectJob> = {}) {

--- a/modules/runner/src/main.ts
+++ b/modules/runner/src/main.ts
@@ -3,11 +3,15 @@ import { Runner } from './runner';
 
 const d = debug('runner');
 
-try {
-  const runner = new Runner();
-  runner.start();
-} catch (err) {
-  d('encountered an error: %O', err);
-  console.error('execution stopped due to a critical error', err);
-  process.exit(1);
+async function main() {
+  try {
+    const runner = new Runner();
+    await runner.start();
+  } catch (err) {
+    d('encountered an error: %O', err);
+    console.error('execution stopped due to a critical error', err);
+    process.exit(1);
+  }
 }
+
+void main();


### PR DESCRIPTION
The previous runner polling loop fired every N msec whether the previous poll was done or not. This caused the same runner to claim a job twice in integration tests.

The new loop sleeps N msec _after_ the poll is done.