### PR TITLE
fix: runner polling loop can accidentally run jobs in parallel

### DIFF
--- a/integration-tests/test/broker-runner.test.ts
+++ b/integration-tests/test/broker-runner.test.ts
@@ -65,7 +65,7 @@ describe('runner', () => {
     await startBroker();
     broker.addTask(task);
     createRunner(runnerOpts);
-    await runner.poll();
+    await runner.pollOnce();
   }
 
   function createBisectTask(job: Partial<BisectJob> = {}) {

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -17,6 +17,7 @@ import { BisectCommand, parseIssueCommand } from './issue-parser';
 import { ElectronVersions } from './electron-versions';
 
 const AppName = 'BugBot' as const;
+const DebugPrefix = 'GitHubClient' as const;
 
 export class GithubClient {
   private isClosed = false;
@@ -32,7 +33,7 @@ export class GithubClient {
     pollIntervalMs: number;
     robot: Probot;
   }) {
-    const d = debug('GithubClient:constructor');
+    const d = debug(`${DebugPrefix}:constructor`);
 
     Object.assign(this, opts);
     d('brokerBaseUrl', this.brokerBaseUrl);
@@ -49,7 +50,7 @@ export class GithubClient {
   }
 
   private listenToRobot() {
-    const d = debug('GithubClient:listenToRobot');
+    const d = debug(`${DebugPrefix}:listenToRobot`);
 
     const debugContext = (context) => d(context.name, inspect(context.payload));
     this.robot.onAny(debugContext);
@@ -80,7 +81,7 @@ export class GithubClient {
   public async onIssueComment(
     context: Context<'issue_comment'>,
   ): Promise<void> {
-    const d = debug('GithubClient:onIssueCommentCreated');
+    const d = debug(`${DebugPrefix}:onIssueComment`);
     d('===> payload <===', JSON.stringify(context.payload));
 
     const { login } = context.payload.comment.user;
@@ -120,7 +121,7 @@ export class GithubClient {
     bisectCmd: BisectCommand,
     context: Context<'issue_comment'>,
   ) {
-    const d = debug('GithubClient:runBisectJob');
+    const d = debug(`${DebugPrefix}:runBisectJob`);
 
     d(`Updating GitHub issue id ${context.payload.issue.id}`);
     const promises: Promise<unknown>[] = [];
@@ -147,7 +148,7 @@ export class GithubClient {
   }
 
   private async pollAndReturnJob(jobId: JobId) {
-    const d = debug('GitHubClient:pollJobId');
+    const d = debug(`${DebugPrefix}:pollAndReturnJob`);
     // FIXME: this state info, such as the timer, needs to be a
     // class property so that '/test stop' could stop the polling.
     // Poll until the job is complete
@@ -189,7 +190,7 @@ export class GithubClient {
     result: Result,
     context: Context<'issue_comment'>,
   ): Promise<void> {
-    const d = debug('GitHubClient:commentBisectResult');
+    const d = debug(`${DebugPrefix}:handleBisectResult`);
     const add_labels = new Set<string>();
     const del_labels = new Set<string>([Labels.BugBot.Running]);
     const paragraphs: string[] = [];

--- a/modules/runner/src/main.ts
+++ b/modules/runner/src/main.ts
@@ -3,11 +3,15 @@ import { Runner } from './runner';
 
 const d = debug('runner');
 
-try {
-  const runner = new Runner();
-  runner.start();
-} catch (err) {
-  d('encountered an error: %O', err);
-  console.error('execution stopped due to a critical error', err);
-  process.exit(1);
+async function main() {
+  try {
+    const runner = new Runner();
+    await runner.start();
+  } catch (err) {
+    d('encountered an error: %O', err);
+    console.error('execution stopped due to a critical error', err);
+    process.exit(1);
+  }
 }
+
+void main();

--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -132,8 +132,8 @@ export class Runner {
   private readonly pollIntervalMs: number;
   private readonly logIntervalMs: number;
   private pollInterval: ReturnType<typeof setInterval>;
+  private runningPromise: Promise<unknown>;
   private stopResolve: (value: unknown) => void;
-  private sleepPromise: Promise<void>;
   private stopping = false;
 
   /**
@@ -169,8 +169,6 @@ export class Runner {
     this.uuid = opts.uuid || uuidv4();
     this.DebugPrefix = `runner:${this.uuid}`;
   }
-
-  private runningPromise: Promise<unknown>;
 
   private isRunning = () => this.runningPromise !== undefined;
 

--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -29,7 +29,7 @@ class Task {
   private logTimer: ReturnType<typeof setTimeout>;
   private readonly logBuffer: string[] = [];
   public readonly timeBegun = Date.now();
-  private readonly DebugPrefix: string;
+  private readonly debugPrefix: string;
 
   constructor(
     public readonly job: Job,
@@ -39,11 +39,11 @@ class Task {
     private readonly brokerUrl: string,
     private readonly logIntervalMs: number,
   ) {
-    this.DebugPrefix = `runner:${this.runner}`;
+    this.debugPrefix = `runner:${this.runner}`;
   }
 
   private async sendLogDataBuffer(url: URL) {
-    const d = debug(`${this.DebugPrefix}:sendLogDataBuffer`);
+    const d = debug(`${this.debugPrefix}:sendLogDataBuffer`);
     delete this.logTimer;
 
     const lines = this.logBuffer.splice(0);
@@ -73,7 +73,7 @@ class Task {
   }
 
   private async sendPatch(patches: Readonly<PatchOp>[]) {
-    const d = debug(`${this.DebugPrefix}:sendPatch`);
+    const d = debug(`${this.debugPrefix}:sendPatch`);
     d('task: %O', this);
     d('patches: %O', patches);
 
@@ -122,7 +122,7 @@ class Task {
 export class Runner {
   public readonly platform: Platform;
   public readonly uuid: RunnerId;
-  private readonly DebugPrefix: string;
+  private readonly debugPrefix: string;
 
   private readonly authToken: string;
   private readonly brokerUrl: string;
@@ -167,13 +167,13 @@ export class Runner {
     this.pollIntervalMs =
       opts.pollIntervalMs || envInt('BUGBOT_POLL_INTERVAL_MS', 20_000);
     this.uuid = opts.uuid || uuidv4();
-    this.DebugPrefix = `runner:${this.uuid}`;
+    this.debugPrefix = `runner:${this.uuid}`;
   }
 
   private isRunning = () => this.runningPromise !== undefined;
 
   public async start() {
-    const d = debug(`${this.DebugPrefix}:start`);
+    const d = debug(`${this.debugPrefix}:start`);
     if (this.isRunning()) throw new Error('already running');
 
     d('entering runner poll loop...');
@@ -184,7 +184,7 @@ export class Runner {
   }
 
   public async stop() {
-    const d = debug(`${this.DebugPrefix}:stop`);
+    const d = debug(`${this.debugPrefix}:stop`);
     if (!this.isRunning()) return;
 
     d('stopping...');
@@ -197,7 +197,7 @@ export class Runner {
   }
 
   private async pollLoop(): Promise<void> {
-    const d = debug(`${this.DebugPrefix}:pollLoop`);
+    const d = debug(`${this.debugPrefix}:pollLoop`);
     while (!this.stopping) {
       const stopPromise = new Promise((r) => (this.stopResolve = r));
 
@@ -215,7 +215,7 @@ export class Runner {
   }
 
   public async pollOnce(): Promise<void> {
-    const d = debug(`${this.DebugPrefix}:pollOnce`);
+    const d = debug(`${this.debugPrefix}:pollOnce`);
 
     const jobId = await this.pickNextJob();
     d(jobId, 'jobId');
@@ -244,7 +244,7 @@ export class Runner {
   }
 
   private async pickNextJob(): Promise<JobId | undefined> {
-    const d = debug(`${this.DebugPrefix}:pickNextJob`);
+    const d = debug(`${this.debugPrefix}:pickNextJob`);
 
     const ids = await this.fetchAvailableJobIds();
     if (!ids.length) return;
@@ -281,7 +281,7 @@ export class Runner {
   }
 
   private async fetchTask(id: JobId): Promise<Task> {
-    const d = debug(`${this.DebugPrefix}:fetchTask`);
+    const d = debug(`${this.debugPrefix}:fetchTask`);
 
     const job_url = new URL(`api/jobs/${id}`, this.brokerUrl);
     const resp = await fetch(job_url, {
@@ -310,7 +310,7 @@ export class Runner {
   }
 
   private async runBisect(task: Task) {
-    const d = debug(`${this.DebugPrefix}:runBisect`);
+    const d = debug(`${this.debugPrefix}:runBisect`);
 
     const { job } = task;
     assertBisectJob(job);
@@ -372,7 +372,7 @@ export class Runner {
     args: string[],
   ): Promise<{ code?: number; error?: string; out: string }> {
     return new Promise((resolve) => {
-      const d = debug(`${this.DebugPrefix}:runFiddle`);
+      const d = debug(`${this.debugPrefix}:runFiddle`);
       const ret = { code: null, out: '', error: null };
 
       const { childTimeoutMs, fiddleExec } = this;

--- a/modules/shared/src/rotary-loop.ts
+++ b/modules/shared/src/rotary-loop.ts
@@ -19,10 +19,10 @@ export class RotaryLoop {
     const d = debug(`${this.debugPrefix}:start`);
     if (this.isRunning) throw new Error('already running');
 
-    d('entering runner poll loop...');
+    d('entering loop...');
     this.runningPromise = this.pollLoop();
     await this.runningPromise;
-    d('...exited runner poll loop');
+    d('...exited loop');
     delete this.runningPromise;
   };
 

--- a/modules/shared/src/rotary-loop.ts
+++ b/modules/shared/src/rotary-loop.ts
@@ -15,7 +15,7 @@ export class RotaryLoop {
     private readonly pollOnce: () => Promise<void>,
   ) {}
 
-  start = async () => {
+  public start = async () => {
     const d = debug(`${this.debugPrefix}:start`);
     if (this.isRunning) throw new Error('already running');
 
@@ -26,7 +26,7 @@ export class RotaryLoop {
     delete this.runningPromise;
   };
 
-  stop = async () => {
+  public stop = async () => {
     const d = debug(`${this.debugPrefix}:stop`);
     if (!this.isRunning) return;
 

--- a/modules/shared/src/rotary-loop.ts
+++ b/modules/shared/src/rotary-loop.ts
@@ -1,0 +1,60 @@
+import debug from 'debug';
+
+export class RotaryLoop {
+  private runningPromise?: Promise<unknown>;
+  private stopResolve?: (value: unknown) => void;
+  private stopping = false;
+
+  private isRunning = () => this.runningPromise !== undefined;
+
+  constructor(
+    private readonly debugPrefix: string,
+    private readonly pollIntervalMs: number,
+    private readonly pollOnce: () => Promise<void>,
+  ) {}
+
+  start = async () => {
+    const d = debug(`${this.debugPrefix}:start`);
+    if (this.isRunning()) throw new Error('already running');
+
+    d('entering runner poll loop...');
+    this.runningPromise = this.pollLoop();
+    await this.runningPromise;
+    d('...exited runner poll loop');
+    delete this.runningPromise;
+  };
+
+  stop = async () => {
+    const d = debug(`${this.debugPrefix}:stop`);
+    if (!this.isRunning()) return;
+
+    d('stopping...');
+    this.stopping = true;
+    this.stopResolve(undefined);
+    await this.runningPromise;
+    delete this.runningPromise;
+    this.stopping = false;
+    d('...stopped');
+  };
+
+  private async pollLoop(): Promise<void> {
+    const d = debug(`${this.debugPrefix}:pollLoop`);
+    while (!this.stopping) {
+      const stopPromise = new Promise((r) => (this.stopResolve = r));
+
+      d('awake; calling pollOnce');
+      try {
+        await this.pollOnce();
+      } catch (err) {
+        console.log('pollOnce threw an error:', err);
+      }
+
+      // sleep until next polling time or stop requested
+      d('sleeping');
+      const ms = this.pollIntervalMs;
+      const sleepPromise = new Promise((r) => setTimeout(r, ms, ms));
+      await Promise.race([stopPromise, sleepPromise]);
+      delete this.stopResolve;
+    }
+  }
+}

--- a/modules/shared/src/rotary-loop.ts
+++ b/modules/shared/src/rotary-loop.ts
@@ -5,17 +5,17 @@ export class RotaryLoop {
   private stopResolve?: (value: unknown) => void;
   private stopping = false;
 
-  private get isRunning(): boolean {
-    return this.runningPromise !== undefined;
-  }
-
   constructor(
     private readonly debugPrefix: string,
     private readonly pollIntervalMs: number,
     private readonly pollOnce: () => Promise<void>,
   ) {}
 
-  public start = async () => {
+  private get isRunning(): boolean {
+    return this.runningPromise !== undefined;
+  }
+
+  public start = async (): Promise<void> => {
     const d = debug(`${this.debugPrefix}:start`);
     if (this.isRunning) throw new Error('already running');
 
@@ -26,7 +26,7 @@ export class RotaryLoop {
     delete this.runningPromise;
   };
 
-  public stop = async () => {
+  public stop = async (): Promise<void> => {
     const d = debug(`${this.debugPrefix}:stop`);
     if (!this.isRunning) return;
 

--- a/modules/shared/src/rotary-loop.ts
+++ b/modules/shared/src/rotary-loop.ts
@@ -5,7 +5,9 @@ export class RotaryLoop {
   private stopResolve?: (value: unknown) => void;
   private stopping = false;
 
-  private isRunning = () => this.runningPromise !== undefined;
+  private get isRunning(): boolean {
+    return this.runningPromise !== undefined;
+  }
 
   constructor(
     private readonly debugPrefix: string,
@@ -15,7 +17,7 @@ export class RotaryLoop {
 
   start = async () => {
     const d = debug(`${this.debugPrefix}:start`);
-    if (this.isRunning()) throw new Error('already running');
+    if (this.isRunning) throw new Error('already running');
 
     d('entering runner poll loop...');
     this.runningPromise = this.pollLoop();
@@ -26,7 +28,7 @@ export class RotaryLoop {
 
   stop = async () => {
     const d = debug(`${this.debugPrefix}:stop`);
-    if (!this.isRunning()) return;
+    if (!this.isRunning) return;
 
     d('stopping...');
     this.stopping = true;


### PR DESCRIPTION
**Note: stacks on top of https://github.com/electron/bugbot/pull/126, which should land first.**

The previous runner polling loop fired every N msec whether the previous poll was done or not. This caused the same runner to claim a job twice in integration tests. Also, Electron Fiddle doesn't like to have two copies of itself running at once, so the runner having two parallel jobs is problematic even when they're not both the same job.

The new loop waits for the previous call to finish first, _then_ sleeps N msec.

*edit:* don't worry about the temporary drop in coverage. The integration test PR at the end of this PR chain will fix it. Honest!