### PR TITLE
feat: limit how frequently the bot updates its issue comment

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,9 @@ const config = {
     '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',
+
+    // a la carte warnings
+    'no-template-curly-in-string': 'error',
   }
 }
 

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -251,7 +251,7 @@ export class GithubClient {
     // don't update too often
     const commentInfo = this.botCommentInfo.get(issueId);
     if (commentInfo && commentInfo.time + this.pollIntervalMs > Date.now()) {
-      d('just updated issue #${issueId} recently; not updating again so soon');
+      d(`just updated issue #${issueId} recently; not updating again so soon`);
       return;
     }
 


### PR DESCRIPTION
As discussed last Friday in the Slack channel, we wanted to get this working first and then make it a little nicer. Friday's PR got it working, so this PR makes it a little nicer.

1. When running the test matrix, ratelimit how frequently the probot client patches its issue comment. The previous implementation patched it every time a job finished. This works, but could generate a lot of traffic since we're potentially running tens of jobs per issue.

2. After all the test promises for an issue settle, send a final patch that bypasses the ratelimit. This is to ensure the final comment has all the results.

3. When patching the bot's comment, do nothing if new comment === old comment. 