### PR TITLE
feat: in test matrix comment, link to Electron release

### DIFF
--- a/modules/bot/src/table-generator.ts
+++ b/modules/bot/src/table-generator.ts
@@ -41,6 +41,10 @@ function generateCell(job: TestJob, brokerBaseUrl: string) {
   return `[${cellLabel(job)}](${logUrl.toString()})`;
 }
 
+function versionMarkdown(version: string) {
+  return `[${version}](https://github.com/electron/electron/releases/tag/v${version})`;
+}
+
 export function generateTable(jobMatrix: Matrix, brokerBaseUrl: string) {
   const d = debug('bot:generateTable');
   d('input matrix %O', jobMatrix);
@@ -57,7 +61,7 @@ export function generateTable(jobMatrix: Matrix, brokerBaseUrl: string) {
 
   // each row is a version with its results per platform
   for (const version of versions) {
-    const versionRow = [version];
+    const versionRow = [versionMarkdown(version)];
 
     for (const plat of platforms) {
       const result = jobMatrix[plat][version] as TestJob;


### PR DESCRIPTION
In the "Electron" column, have the version number link to that version's release + release notes.

before:

| Electron                                                            |                                                                             Linux |
| :------------------------------------------------------------------ | --------------------------------------------------------------------------------: |
| 12.0.0 | [Failed&ensp;🔴](http://localhost:43493/log/9b40d7ec-878c-4416-b181-968ed38642c2) | +1ms

after:

| Electron                                                            |                                                                             Linux |
| :------------------------------------------------------------------ | --------------------------------------------------------------------------------: |
| [12.0.0](https://github.com/electron/electron/releases/tag/v12.0.0) | [Failed&ensp;🔴](http://localhost:43493/log/9b40d7ec-878c-4416-b181-968ed38642c2) | +1ms
