### PR TITLE
build: omit noop from integration-tests package.json

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "build": "# no-op",
+    "build": "tsc -b",
     "test": "jest --runInBand",
     "test:ci": "jest --runInBand --coverage"
   },


### PR DESCRIPTION
when `yarn build` is run, have integration-tests/ call `tsc -b` instead of `# no-op` because the latter does not work on PowerShell: 

```
> @electron/bugbot-runner-integration-tests
$ # no-op
'#' is not recognized as an internal or external command,
operable program or batch file.
error Command failed with exit code 1.
```

