### PR TITLE
Revert "build: import sibling workspaces from src/, not build/ (#138)"

### DIFF
--- a/integration-tests/test/bot-broker-runner.test.ts
+++ b/integration-tests/test/bot-broker-runner.test.ts
@@ -22,7 +22,7 @@ import {
   Result,
   TestJob,
   VersionRange,
-} from '@electron/bugbot-shared/src/interfaces';
+} from '@electron/bugbot-shared/build/interfaces';
 
 jest.setTimeout(60_000);
 

--- a/integration-tests/test/broker-runner.test.ts
+++ b/integration-tests/test/broker-runner.test.ts
@@ -16,7 +16,7 @@ import {
   Result,
   TestJob,
   VersionRange,
-} from '@electron/bugbot-shared/src/interfaces';
+} from '@electron/bugbot-shared/build/interfaces';
 
 jest.setTimeout(60_000);
 

--- a/modules/bot/src/broker-client.ts
+++ b/modules/bot/src/broker-client.ts
@@ -3,13 +3,14 @@ import fetch from 'node-fetch';
 import { URL } from 'url';
 import { v4 as mkuuid } from 'uuid';
 
+// import { FiddleBisectResult } from '@electron/bugbot-runner/build/fiddle-bisect-parser';
 import {
   BisectJob,
   Job,
   JobId,
   JobType,
   TestJob,
-} from '@electron/bugbot-shared/src/interfaces';
+} from '@electron/bugbot-shared/build/interfaces';
 
 import { BisectCommand, TestCommand } from './issue-parser';
 

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -9,8 +9,8 @@ import {
   JobId,
   JobType,
   TestJob,
-} from '@electron/bugbot-shared/src/interfaces';
-import { env, envInt } from '@electron/bugbot-shared/src/env-vars';
+} from '@electron/bugbot-shared/build/interfaces';
+import { env, envInt } from '@electron/bugbot-shared/build/env-vars';
 
 import BrokerAPI from './broker-client';
 import { Labels } from './github-labels';

--- a/modules/bot/src/issue-parser.ts
+++ b/modules/bot/src/issue-parser.ts
@@ -6,7 +6,7 @@ import { Heading } from 'mdast';
 import { Node } from 'unist';
 import { inspect } from 'util';
 import { ElectronVersions, releaseCompare } from './electron-versions';
-import { Platform } from '@electron/bugbot-shared/src/interfaces';
+import { Platform } from '@electron/bugbot-shared/build/interfaces';
 
 // no types exist for this module
 //eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -12,7 +12,7 @@ import {
   BisectJob,
   JobType,
   Result,
-} from '@electron/bugbot-shared/src/interfaces';
+} from '@electron/bugbot-shared/build/interfaces';
 import { Labels } from '../src/github-labels';
 
 jest.mock('../src/broker-client');

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -8,8 +8,8 @@ import express from 'express';
 import { URL } from 'url';
 import { klona } from 'klona/json';
 
-import { assertJob } from '@electron/bugbot-shared/src/interfaces';
-import { env, getEnvData } from '@electron/bugbot-shared/src/env-vars';
+import { assertJob } from '@electron/bugbot-shared/build/interfaces';
+import { env, getEnvData } from '@electron/bugbot-shared/build/env-vars';
 
 import { ALL_SCOPES, Auth, AuthScope } from './auth';
 import { Broker } from './broker';

--- a/modules/broker/src/task.ts
+++ b/modules/broker/src/task.ts
@@ -6,7 +6,7 @@ import {
   Job,
   RunnerId,
   assertJob,
-} from '@electron/bugbot-shared/src/interfaces';
+} from '@electron/bugbot-shared/build/interfaces';
 
 class LogSection {
   public readonly runner: RunnerId;

--- a/modules/broker/test/broker.spec.ts
+++ b/modules/broker/test/broker.spec.ts
@@ -14,7 +14,7 @@ import {
   Platform,
   Result,
   VersionRange,
-} from '@electron/bugbot-shared/src/interfaces';
+} from '@electron/bugbot-shared/build/interfaces';
 import { Auth, AuthScope } from '../src/auth';
 import { Server } from '../src/server';
 

--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -20,9 +20,9 @@ import {
   assertJob,
   assertBisectJob,
   assertTestJob,
-} from '@electron/bugbot-shared/src/interfaces';
-import { RotaryLoop } from '@electron/bugbot-shared/src/rotary-loop';
-import { env, envInt } from '@electron/bugbot-shared/src/env-vars';
+} from '@electron/bugbot-shared/build/interfaces';
+import { RotaryLoop } from '@electron/bugbot-shared/build/rotary-loop';
+import { env, envInt } from '@electron/bugbot-shared/build/env-vars';
 
 import { parseFiddleBisectOutput } from './fiddle-bisect-parser';
 


### PR DESCRIPTION
This reverts commit 51afb54429a955fd50b25057255f909c023b7366.