### PR TITLE
feat: add remote metric logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Much like [trop](https://github.com/electron/trop/blob/master/docs/usage.md#usin
 | `BUGBOT_POLL_INTERVAL_MS` | Bot, Runner | How frequently to poll the Broker | 20 seconds |
 | `BUGBOT_AUTH_TOKEN` | Required: Bot, Runner; Optional: Broker | The auth token for communications with the Broker |
 | `BUGBOT_GITHUB_LOGIN` | Bot | The name of the GitHub app registered for the Probot client |
+| `BUGBOT_LOG_METRICS_URL` | Broker | The remote Loki endpoint to send log metrics to |
+| `BUGBOT_LOG_METRICS_AUTH` | Broker | The (`Basic`) auth credentials to authenticate log metrics requests with |
 
 ## Development
 

--- a/modules/bot/package.json
+++ b/modules/bot/package.json
@@ -29,7 +29,7 @@
     "@types/markdown-table": "^2.0.0",
     "@types/mdast": "^3.0.3",
     "@types/node": "^15.3.0",
-    "@types/node-fetch": "^2.5.10",
+    "@types/node-fetch": "^2.5.11",
     "@types/semver": "^7.3.6",
     "@types/unist": "^2.0.3",
     "jest": "^26.6.3",

--- a/modules/broker/package.json
+++ b/modules/broker/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@types/escape-html": "^1.0.1",
     "@types/etag": "^1.8.0",
-    "@types/express": "^4.17.12"
+    "@types/express": "^4.17.12",
+    "@types/node-fetch": "^2.5.11"
   }
 }

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -10,6 +10,7 @@ import { klona } from 'klona/json';
 
 import { assertJob } from '@electron/bugbot-shared/build/interfaces';
 import { env, getEnvData } from '@electron/bugbot-shared/build/env-vars';
+import { logMetric } from '@electron/bugbot-shared/build/log-metric';
 
 import { ALL_SCOPES, Auth, AuthScope } from './auth';
 import { Broker } from './broker';
@@ -149,6 +150,10 @@ export class Server {
       assertJob(req.body);
       const task = new Task(req.body);
       this.broker.addTask(task);
+      logMetric(`created new task ${task.job.id}`, {
+        module: 'broker',
+        event: 'task_created',
+      });
       res.status(201).send(escapeHtml(task.job.id));
     } catch (error: unknown) {
       d('bad job', error);

--- a/modules/broker/src/server.ts
+++ b/modules/broker/src/server.ts
@@ -150,10 +150,12 @@ export class Server {
       assertJob(req.body);
       const task = new Task(req.body);
       this.broker.addTask(task);
-      logMetric(`created new task ${task.job.id}`, {
-        module: 'broker',
-        event: 'task_created',
-      });
+      logMetric(
+        {
+          event: 'task_created',
+        },
+        { module: 'broker' },
+      );
       res.status(201).send(escapeHtml(task.job.id));
     } catch (error: unknown) {
       d('bad job', error);

--- a/modules/runner/package.json
+++ b/modules/runner/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.5",
     "@types/jest": "^26.0.23",
+    "@types/node-fetch": "^2.5.11",
     "@types/uuid": "^8.3.0",
     "@types/which": "^2.0.1",
     "jest": "^26.6.3"

--- a/modules/shared/package.json
+++ b/modules/shared/package.json
@@ -10,12 +10,14 @@
   },
   "dependencies": {
     "debug": "^4.3.2",
+    "node-fetch": "^2.6.1",
     "ow": "^0.26.0",
     "semver": "^7.3.5",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
+    "@types/node-fetch": "^2.5.11",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6"
   }

--- a/modules/shared/src/log-metric.ts
+++ b/modules/shared/src/log-metric.ts
@@ -1,0 +1,71 @@
+import debug = require('debug');
+import fetch from 'node-fetch';
+
+/**
+ * Logs a metric to a remote logging server, defined by the environment vars:
+ * - `BUGBOT_LOG_METRICS_URL`
+ * - `BUGBOT_LOG_METRICS_AUTH`
+ *
+ * This code assumes that it is sending logs to an instance of Grafana Loki,
+ * with the data format defined by:
+ * https://grafana.com/docs/loki/latest/api/#post-lokiapiv1push
+ */
+export function logMetric(
+  message: string,
+  labels?: Record<string, string>,
+): void {
+  const now = Date.now();
+  const d = debug('log-metric');
+
+  const envUrl = process.env.BUGBOT_LOG_METRICS_URL; // required
+  const envAuth = process.env.BUGBOT_LOG_METRICS_AUTH;
+
+  // Ensure that the URL to send logs to is present
+  if (envUrl === undefined) {
+    d('missing URL; no-op');
+    return;
+  }
+
+  // Craft the payload
+  const payload = {
+    streams: [
+      {
+        stream: {
+          ...(labels || {}),
+          app: 'bugbot',
+        },
+        values: [[Math.round(now * 1000000).toString(), message]],
+      },
+    ],
+  };
+
+  // Start the request
+  const req = fetch(envUrl, {
+    body: JSON.stringify(payload),
+    headers: {
+      'Content-Type': 'application/json',
+      ...(envAuth !== undefined
+        ? {
+            Authorization: `Basic ${Buffer.from(envAuth).toString('base64')}`,
+          }
+        : {}),
+    },
+    method: 'POST',
+  });
+
+  // Watch the response, but in general ignore failures
+  req
+    .then((res) => {
+      if (res.status === 204) {
+        // Status 204 = No Content & success; do nothing
+        d('successfully logged metric');
+        return;
+      }
+
+      // Something must have gone wrong, log a debug error
+      return res.text().then((data) => d('unexpected response:', data));
+    })
+    .catch((err) => {
+      d('error', err);
+    });
+}

--- a/modules/shared/src/log-metric.ts
+++ b/modules/shared/src/log-metric.ts
@@ -12,9 +12,8 @@ import fetch from 'node-fetch';
  */
 export function logMetric(
   message: string,
-  labels?: Record<string, string>,
+  labels: Record<string, string> = {},
 ): void {
-  const now = Date.now();
   const d = debug('log-metric');
 
   const envUrl = process.env.BUGBOT_LOG_METRICS_URL; // required
@@ -34,7 +33,7 @@ export function logMetric(
           ...(labels || {}),
           app: 'bugbot',
         },
-        values: [[Math.round(now * 1000000).toString(), message]],
+        values: [[Math.round(Date.now() * 1_000_000).toString(), message]],
       },
     ],
   };

--- a/modules/shared/src/log-metric.ts
+++ b/modules/shared/src/log-metric.ts
@@ -10,11 +10,12 @@ import fetch from 'node-fetch';
  * with the data format defined by:
  * https://grafana.com/docs/loki/latest/api/#post-lokiapiv1push
  *
- * The message can either be a string, which is sent raw, or an object that is
- * serialized and sent as JSON.
+ * `data` is the metric data that you would expect to change in each log message
+ * or even across different types of log messages; `labels` are common among a
+ * large group of different kinds of log messages (e.g. which module made it).
  */
 export function logMetric(
-  message: string | Record<string, any>,
+  data: Record<string, any>,
   labels: Record<string, string> = {},
 ): void {
   const d = debug('log-metric');
@@ -29,8 +30,6 @@ export function logMetric(
   }
 
   // Craft the payload
-  const logMsg =
-    typeof message === 'string' ? message : JSON.stringify(message);
   const payload = {
     streams: [
       {
@@ -38,7 +37,9 @@ export function logMetric(
           ...(labels || {}),
           app: 'bugbot',
         },
-        values: [[Math.round(Date.now() * 1_000_000).toString(), logMsg]],
+        values: [
+          [Math.round(Date.now() * 1_000_000).toString(), JSON.stringify(data)],
+        ],
       },
     ],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,6 +1080,14 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
+"@types/node-fetch@^2.5.11":
+  version "2.5.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.11.tgz#ce22a2e65fc8999f4dbdb7ddbbcf187d755169e4"
+  integrity sha512-2upCKaqVZETDRb8A2VTaRymqFBEgH8u6yr96b/u3+1uQEPDRo3mJLEiPk7vdXBHRtjwkjqzFYMJXrt0Z9QsYjQ==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.0.0.tgz#067a6c49dc7a5c2412a505628e26902ae967bf6f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,14 +1072,6 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
 
-"@types/node-fetch@^2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
-  integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
-  dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
 "@types/node-fetch@^2.5.11":
   version "2.5.11"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.11.tgz#ce22a2e65fc8999f4dbdb7ddbbcf187d755169e4"


### PR DESCRIPTION
Adds some code to log metrics to a remote server, specifically one hosting an instance of [Grafana Loki](https://grafana.com/oss/loki/). Metrics are done as send-and-forget with only some logging on top of the request to the remote server.

To enable the feature the `BUGBOT_LOG_METRICS_URL` env var must be set, then metrics will be sent there. Additionally, if the request requires authentication, the `BUGBOT_LOG_METRICS_AUTH` env var can be set to pass the correct HTTP `Authorization` header (using the `Basic` auth scheme). (Maintainers: see slack for more context here.)