### PR TITLE
feat: better 'hello world' comment for test matrix

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -165,8 +165,6 @@ export class GithubClient {
       command.versions,
     );
 
-    await this.setIssueComment('Queuing bisect job...', context);
-
     // queue all jobs for matrix
     const matrix: Matrix = {};
     const queueJobPromises: Promise<string>[] = [];
@@ -188,6 +186,9 @@ export class GithubClient {
         );
       }
     }
+
+    // set initial matrix comment
+    await this.setIssueMatrixComment(matrix, context);
 
     const ids = await Promise.all(queueJobPromises);
 

--- a/modules/bot/src/table-generator.ts
+++ b/modules/bot/src/table-generator.ts
@@ -10,10 +10,9 @@ export interface Matrix {
   win32?: any;
 }
 
-function pendingLabel() {
-  return 'Pending&ensp;🟡';
-}
-function cellLabel(job: TestJob) {
+const pendingLabel = 'Pending&ensp;🟡';
+
+function getJobLabel(job: TestJob) {
   switch (job.last?.status) {
     case 'success':
       return 'Passed&ensp;🟢';
@@ -24,7 +23,7 @@ function cellLabel(job: TestJob) {
     case 'test_error':
       return 'Test Error&ensp;🔵';
     default:
-      return pendingLabel();
+      return pendingLabel;
   }
 }
 
@@ -41,11 +40,11 @@ function platformDisplayName(platform: Platform) {
 
 function generateCell(job: TestJob, brokerBaseUrl: string) {
   // if job hasn't been allocated yet, show it as pending
-  if (!job?.id) return pendingLabel();
+  if (!job?.id) return pendingLabel;
 
   // job has been allocated, so we can link to the log
   const logUrl = new URL(`/log/${job.id}`, brokerBaseUrl);
-  return `[${cellLabel(job)}](${logUrl.toString()})`;
+  return `[${getJobLabel(job)}](${logUrl.toString()})`;
 }
 
 function versionMarkdown(version: string) {

--- a/modules/bot/src/table-generator.ts
+++ b/modules/bot/src/table-generator.ts
@@ -10,6 +10,9 @@ export interface Matrix {
   win32?: any;
 }
 
+function pendingLabel() {
+  return 'Pending&ensp;🟡';
+}
 function cellLabel(job: TestJob) {
   switch (job.last?.status) {
     case 'success':
@@ -21,7 +24,7 @@ function cellLabel(job: TestJob) {
     case 'test_error':
       return 'Test Error&ensp;🔵';
     default:
-      return 'Pending&ensp;🟡';
+      return pendingLabel();
   }
 }
 
@@ -37,6 +40,10 @@ function platformDisplayName(platform: Platform) {
 }
 
 function generateCell(job: TestJob, brokerBaseUrl: string) {
+  // if job hasn't been allocated yet, show it as pending
+  if (!job?.id) return pendingLabel();
+
+  // job has been allocated, so we can link to the log
   const logUrl = new URL(`/log/${job.id}`, brokerBaseUrl);
   return `[${cellLabel(job)}](${logUrl.toString()})`;
 }


### PR DESCRIPTION
Previously we had a placeholder comment saying 'queueing bisect job'; this PR changes that to show a matrix showing all the jobs that are pending.