### PR TITLE
chore: terser URL strings in debug logs

### DIFF
--- a/modules/bot/src/broker-client.ts
+++ b/modules/bot/src/broker-client.ts
@@ -29,7 +29,7 @@ export default class BrokerAPI {
     const d = debug(`${DebugPrefix}:queueBisectJob`);
 
     const url = new URL('/api/jobs', this.baseURL);
-    d('url', url);
+    d('url', url.toString());
 
     const bisectJob: BisectJob = {
       gist: command.gistId,
@@ -62,7 +62,7 @@ export default class BrokerAPI {
     const d = debug(`${DebugPrefix}:queueTestJob`);
 
     const url = new URL('/api/jobs', this.baseURL);
-    d('queueing test command via %s', url);
+    d('queueing test command via %s', url.toString());
 
     // FIXME(any): We should add a separate type here so that we can
     // pass in a single version and platform to this function
@@ -103,7 +103,7 @@ export default class BrokerAPI {
     const d = debug(`${DebugPrefix}:getJob`);
 
     const url = new URL(`/api/jobs/${jobId}`, this.baseURL);
-    d('url', url);
+    d('url', url.toString());
 
     const response = await fetch(url.toString(), {
       headers: {
@@ -121,7 +121,7 @@ export default class BrokerAPI {
     const d = debug(`${DebugPrefix}:completeJob`);
 
     const url = new URL(`/api/jobs/${jobId}`, this.baseURL);
-    d('url', url);
+    d('url', url.toString());
 
     const response = await fetch(url.toString(), {
       body: JSON.stringify([


### PR DESCRIPTION
No production changes; just fixes a wart in our logs. Right now we have a few places that say something like this:

```ts
d('url', url);
```

Which generates a prolix multiline dump of the URL object:

```
2021-07-21T19:46:43.774408+00:00 app[web.1]: 2021-07-21T19:46:43.774Z bot:BrokerAPI:getJob url URL {
2021-07-21T19:46:43.774409+00:00 app[web.1]: href: 'https://bugbot-broker.herokuapp.com/api/jobs/8f6dce53-3380-4a80-b47a-27b11c1d5aa2',
2021-07-21T19:46:43.774410+00:00 app[web.1]: origin: 'https://bugbot-broker.herokuapp.com',
2021-07-21T19:46:43.774410+00:00 app[web.1]: protocol: 'https:',
2021-07-21T19:46:43.774411+00:00 app[web.1]: username: '',
2021-07-21T19:46:43.774411+00:00 app[web.1]: password: '',
2021-07-21T19:46:43.774412+00:00 app[web.1]: host: 'bugbot-broker.herokuapp.com',
2021-07-21T19:46:43.774412+00:00 app[web.1]: hostname: 'bugbot-broker.herokuapp.com',
2021-07-21T19:46:43.774412+00:00 app[web.1]: port: '',
2021-07-21T19:46:43.774413+00:00 app[web.1]: pathname: '/api/jobs/8f6dce53-3380-4a80-b47a-27b11c1d5aa2',
2021-07-21T19:46:43.774413+00:00 app[web.1]: search: '',
2021-07-21T19:46:43.774413+00:00 app[web.1]: searchParams: URLSearchParams {},
2021-07-21T19:46:43.774414+00:00 app[web.1]: hash: ''
2021-07-21T19:46:43.774414+00:00 app[web.1]: }
```

This PR changes that to a `.toString()` so that the log is easier to read / less cluttered with this noise.