### PR TITLE
feat: do not sleep when jobs are waiting in runner

### DIFF
--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -186,12 +186,11 @@ export class Runner {
   public stop = () => this.loop.stop();
 
   public pollOnce = async (): Promise<void> => {
+    let task: Task | undefined;
     const d = debug(`${this.debugPrefix}:pollOnce`);
 
-    for (;;) {
-      const task = await this.claimNextTask();
+    while ((task = await this.claimNextTask())) {
       d('next task: %o', task);
-      if (!task) return;
 
       // run the job
       d(task.job.id, 'running job');

--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -188,26 +188,28 @@ export class Runner {
   public pollOnce = async (): Promise<void> => {
     const d = debug(`${this.debugPrefix}:pollOnce`);
 
-    const task = await this.claimNextTask();
-    d('next task: %o', task);
-    if (!task) return;
+    for (;;) {
+      const task = await this.claimNextTask();
+      d('next task: %o', task);
+      if (!task) return;
 
-    // run the job
-    d(task.job.id, 'running job');
-    let result: Partial<Result>;
-    switch (task.job.type) {
-      case JobType.bisect:
-        result = await this.runBisect(task);
-        break;
+      // run the job
+      d(task.job.id, 'running job');
+      let result: Partial<Result>;
+      switch (task.job.type) {
+        case JobType.bisect:
+          result = await this.runBisect(task);
+          break;
 
-      case JobType.test:
-        result = await this.runTest(task);
-        break;
+        case JobType.test:
+          result = await this.runTest(task);
+          break;
+      }
+
+      d(task.job.id, 'sending result');
+      await task.sendResult(result);
+      d('done');
     }
-
-    d(task.job.id, 'sending result');
-    await task.sendResult(result);
-    d('done');
   };
 
   private async claimNextTask(): Promise<Task | undefined> {


### PR DESCRIPTION
Only put the runner to sleep for intervalMsec when there are no jobs for it to run.

Previously it was going to sleep after every job it finished.