### PR TITLE
chore: slightly terser runner debug logging

### DIFF
--- a/modules/runner/src/runner.ts
+++ b/modules/runner/src/runner.ts
@@ -78,8 +78,9 @@ class Task {
    */
   private async sendPatch(patches: Readonly<PatchOp>[]): Promise<boolean> {
     const d = debug(`${this.debugPrefix}:sendPatch`);
-    d('task: %O', this);
-    d('patches: %O', patches);
+    d('job: %o', this.job);
+    d('patches:');
+    for (const patch of patches) d('%o', patch);
 
     // Send the patch
     const job_url = new URL(`api/jobs/${this.job.id}`, this.brokerUrl);
@@ -274,7 +275,7 @@ export class Runner {
     }
 
     const job = await resp.json();
-    d('job %O', job);
+    d('job %o', job);
     assertJob(job);
     return new Task(
       job,
@@ -365,8 +366,7 @@ export class Runner {
       ] as const;
       task.addLogData(startupLog.join('\n'));
 
-      d('exec: %s', fiddleExec);
-      d('args: %o', args);
+      d(`${fiddleExec} ${args.join(' ')}`);
       d('opts: %o', opts);
       const child = spawn(fiddleExec, args, opts);
 


### PR DESCRIPTION
Similar to the narrowly-focused bot logging PR from Wednesday (#150).

- When logging a json patch, show one patch per line
- Log the job being patched, rather than the Task object that holds the job. The Task has a lot of data unrelated to the json patch, e.g. the log buffer.
- When spawning, log the exec + args in a method that is easier to copy & paste elsewhere in case you need to reproduce the test manually. Currently ["it", "is", "formatted", "like", "this"] which is not convenient for copy -> paste -> run from a command line.