### PR TITLE
feat: bot should make new comments for new tasks

### DIFF
--- a/integration-tests/test/bot-broker-runner.test.ts
+++ b/integration-tests/test/bot-broker-runner.test.ts
@@ -140,8 +140,8 @@ describe('bot-broker-runner', () => {
       .get(`${projectPath}/collaborators/erickzhao/permission`)
       .reply(200, { permission: 'admin' })
       .post(`${issuePath}/labels`).reply(200)
-      .get(`${issuePath}/comments?per_page=100`).reply(200, []) // No comments yet...
-      .post(`${issuePath}/comments`).reply(200, { id: botCommentId }) // ...so we create a new comment
+      // create a new comment:
+      .post(`${issuePath}/comments`).reply(200, { id: botCommentId })
       .delete(`${issuePath}/labels/bugbot%2Ftest-running`).reply(200)
       // ... task runs...
       .post(`${issuePath}/labels`).reply(200)
@@ -191,9 +191,7 @@ describe('bot-broker-runner', () => {
       // should we respond to this comment? yes, it's from an admin
       .get(`${projectPath}/collaborators/erickzhao/permission`)
       .reply(200, { permission: 'admin' })
-      // looking for any existing comment already posted by the bot...
-      .get(`${issuePath}/comments?per_page=100`).reply(200, [])
-      // nope; so no comment yet, so create one
+      // create a new comment:
       .post(`${issuePath}/comments`).reply(200, { id: botCommentId })
       // and when the test is finished, update the comment
       .patch(`${projectPath}/issues/comments/${botCommentId}`).reply(200);

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -122,11 +122,7 @@ describe('github-client', () => {
           .mockResolvedValueOnce(mockJobDone);
 
         nockScope
-          // No comments yet...
-          .get(`${issuePath}/comments?per_page=100`)
-          .reply(200, [])
-
-          // ...so we create a new comment
+          // Create a new comment
           .post(`${issuePath}/comments`, ({ body }) => {
             expect(body).toEqual('Queuing bisect job...');
             return true;
@@ -194,11 +190,7 @@ describe('github-client', () => {
         mockGetJob.mockResolvedValueOnce(mockJob);
 
         nockScope
-          // No comments yet...
-          .get(`${issuePath}/comments?per_page=100`)
-          .reply(200, [])
-
-          // ...so we create a new comment
+          // Create a new comment
           .post(`${issuePath}/comments`, ({ body }) => {
             expect(body).toEqual('Queuing bisect job...');
             return true;


### PR DESCRIPTION
Fixes #153.

When running a task, e.g. a bisect or a test matrix, keep patching the current comment until the task is done. Once it's done, make a new comment so that future invocations won't overwrite the previous work.

I wonder if this will cause other (smaller) issues; but of the ideas listed in that ticket so far, this approach makes the most sense to me.