### PR TITLE
feat: add a gist link to the test matrix comment

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -188,7 +188,7 @@ export class GithubClient {
     }
 
     // set initial matrix comment
-    await this.setIssueMatrixComment(matrix, context);
+    await this.setIssueMatrixComment(matrix, context, command.gistId);
 
     const ids = await Promise.all(queueJobPromises);
 
@@ -203,7 +203,7 @@ export class GithubClient {
 
     await Promise.all(ids.map((id) => awaitOneJob(id)));
     d('all promises settled; sending final update');
-    await this.setIssueMatrixComment(matrix, context);
+    await this.setIssueMatrixComment(matrix, context, command.gistId);
     d(`All ${ids.length} test jobs complete!`);
   }
 
@@ -256,15 +256,18 @@ export class GithubClient {
       return;
     }
 
-    await this.setIssueMatrixComment(matrix, context);
+    await this.setIssueMatrixComment(matrix, context, job.gist);
   }
 
   private async setIssueMatrixComment(
     matrix: Matrix,
     context: Context<'issue_comment'>,
+    gist: string,
   ) {
     const d = debug(`${DebugPrefix}:setIssueMatrixComment`);
-    const body = generateTable(matrix, this.brokerBaseUrl);
+    const link = `Testing https://gist.github.com/${gist}`;
+    const table = generateTable(matrix, this.brokerBaseUrl);
+    const body = [link, table].join('\n\n');
     d(`issueId ${context.payload.issue.id} body:\n${body}`);
     await this.setIssueComment(body, context);
   }

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -267,7 +267,8 @@ export class GithubClient {
     const d = debug(`${DebugPrefix}:setIssueMatrixComment`);
     const link = `Testing https://gist.github.com/${gist}`;
     const table = generateTable(matrix, this.brokerBaseUrl);
-    const body = [link, table].join('\n\n');
+    const footer = `*I am a bot. [Learn more about what I can do!](https://github.com/electron/bugbot#readme)*`;
+    const body = [link, table, footer].join('\n\n');
     d(`issueId ${context.payload.issue.id} body:\n${body}`);
     await this.setIssueComment(body, context);
   }


### PR DESCRIPTION
Does what it says on the tin -- in bugbot's test matrix issue comment, add a link to the gist being tested.