### PR TITLE
build: disable new eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ const config = {
     '@typescript-eslint/no-unsafe-call': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unsafe-return': 'off',
+    '@typescript-eslint/restrict-template-expressions': 'off',
 
     // a la carte warnings
     'no-template-curly-in-string': 'error',


### PR DESCRIPTION
A fresh checkout of bugbot no longer passes lint tests due to new `@typescript-eslint/restrict-template-expressions` warnings. As a workaround, this PR disables those warnings.

As an example,

```ts
jobId: JobId = .. ;
console.log(`${jobId});
```

will generate a warning even though [JobId is a type alias for string](https://github.com/electron/bugbot/blob/3c15faaba1eeedbd276104b7770d19769f43cdea/modules/shared/src/interfaces.ts#L13). eslint thinks that it is an 'any', either because it's failing to resolve the correct type, or because it is intentionally restricting type aliases because it's bad practice to assume an alias' type.

Other alternatives would be

- remove the type aliases and just have jobIds be strings
- get more creative about how they're used, e.g. replace `api/jobs/${jobId}` with `['api', 'jobs', jobId].join('/')`

I'd be ok with the first. The second smells more like coding around the problem than solving it.