### PR TITLE
fix: don't strip empty lines from the runner's log

### DIFF
--- a/modules/broker/src/task.ts
+++ b/modules/broker/src/task.ts
@@ -37,7 +37,7 @@ export class Task {
     }
 
     d('appending to log:', data);
-    const lines = data.split(/\r?\n/).filter((line) => line?.length > 0);
+    const lines = data.split(/\r?\n/);
     log[log.length - 1].lines.push(...lines);
   }
 


### PR DESCRIPTION
Does what it says on the tin.

The broker is stripping out empty lines from the log, even if those empty lines make the output more human-readable.