### PR TITLE
refactor: remove unused bot BrokerClient.completeJob()

### DIFF
--- a/modules/bot/src/broker-client.ts
+++ b/modules/bot/src/broker-client.ts
@@ -116,25 +116,4 @@ export default class BrokerAPI {
 
     return response.json();
   }
-
-  public async completeJob(jobId: JobId): Promise<void> {
-    const d = debug(`${DebugPrefix}:completeJob`);
-
-    const url = new URL(`/api/jobs/${jobId}`, this.baseURL);
-    d('url', url.toString());
-
-    const response = await fetch(url.toString(), {
-      body: JSON.stringify([
-        { op: 'replace', path: '/bot_client_data', value: 'complete' },
-      ]),
-      headers: {
-        Authorization: `Bearer ${this.authToken}`,
-        'Content-Type': 'application/json',
-      },
-      method: 'PATCH',
-    });
-
-    const { status, statusText } = response;
-    d('status', status, 'statusText', statusText);
-  }
 }

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -227,7 +227,6 @@ export class GithubClient {
         } else {
           d(`${jobId}: complete 🚀 `);
           try {
-            await this.broker.completeJob(jobId);
             return resolve(job);
           } catch (e) {
             return reject(e);

--- a/modules/bot/test/github-client.spec.ts
+++ b/modules/bot/test/github-client.spec.ts
@@ -23,7 +23,6 @@ describe('github-client', () => {
   const pollIntervalMs = 10;
 
   let ghclient: GithubClient;
-  let mockCompleteJob: jest.Mock;
   let mockGetJob: jest.Mock;
   let mockQueueBisectJob: jest.Mock;
   let mockStopJob: jest.Mock;
@@ -31,13 +30,11 @@ describe('github-client', () => {
   let nockScope: Scope;
 
   beforeEach(() => {
-    mockCompleteJob = jest.fn();
     mockGetJob = jest.fn();
     mockStopJob = jest.fn();
     mockQueueBisectJob = jest.fn();
     (BrokerAPI as jest.Mock).mockImplementation(() => {
       return {
-        completeJob: mockCompleteJob,
         getJob: mockGetJob,
         queueBisectJob: mockQueueBisectJob,
         stopJob: mockStopJob,
@@ -163,8 +160,6 @@ describe('github-client', () => {
           name: 'issue_comment',
           payload: payloadFixture,
         } as any);
-
-        expect(mockCompleteJob).toHaveBeenCalledWith(id);
       });
 
       it('handles failures gracefully', async () => {
@@ -228,8 +223,6 @@ describe('github-client', () => {
           name: 'issue_comment',
           payload: payloadFixture,
         } as any);
-
-        expect(mockCompleteJob).toHaveBeenCalledWith(mockJob.id);
       });
 
       it.todo('stops a test job if one is running');


### PR DESCRIPTION
We're not using the `bot_client_data` field, so this PR removes the code that touches it.

*edit:* literally no new code. Coveralls dropped because some of the removed LOC had test coverage.