### PR TITLE
refactor: change how issue comment is updated during test matrix

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -224,7 +224,7 @@ export class GithubClient {
         return job;
       }
       d('polled and still pending 🐌', JSON.stringify(job));
-      await new Promise((r) => setTimeout(r, ms));
+      await new Promise((r) => setTimeout(r, ms, ms));
     }
   }
 

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -224,7 +224,7 @@ export class GithubClient {
         return job;
       }
       d('polled and still pending 🐌', JSON.stringify(job));
-      await new Promise((r) => setTimeout(r, ms, ms));
+      await new Promise((r) => setTimeout(r, ms));
     }
   }
 

--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -190,10 +190,10 @@ export class GithubClient {
     d(`All ${ids.length} jobs queued: %o`, ids);
 
     // while the jobs are running, periodically update the comment
-    const CommentIntervalMsec = 5_000;
+    const COMMENT_INTERVAL_MSEC = 5_000 as const;
     const updateComment = () =>
       this.setIssueMatrixComment(matrix, context, command.gistId);
-    const interval = setInterval(updateComment, CommentIntervalMsec);
+    const interval = setInterval(updateComment, COMMENT_INTERVAL_MSEC);
     await updateComment();
 
     // poll jobs until they're all settled


### PR DESCRIPTION
As mentioned earlier today, this is still flushing out the queue of a couple of refactors that I did during the end of the last sprint.

When building a test matrix, have the probot bot try to periodically update the issue comment every few seconds.

GithubClient.setIssueComment() still has a safety check to do nothing if the content is unchanged since last time, so we still won't be generating redundant network traffic. The idea here is to try and flush new changes to the matrix back up to github more quickly.