### PR TITLE
fix: linting in integration-tests submodule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ const config = {
   parserOptions: {
     ecmaVersion: 2020,
     project: [
-      './integration-tests/tsconfig.json',
+      './integration-tests/tsconfig.eslint.json',
       './modules/bot/tsconfig.eslint.json',
       './modules/broker/tsconfig.eslint.json',
       './modules/runner/tsconfig.eslint.json',

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -3,13 +3,14 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "build": "tsc -b",
+    "build": "run-p -s",
     "test": "jest --runInBand",
     "test:ci": "jest --runInBand --coverage"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
     "jest": "^26.6.3",
+    "npm-run-all": "^4.1.5",
     "object-hash": "^2.2.0",
     "uuid": "^8.3.2"
   }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -3,14 +3,13 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "build": "run-p -s",
+    "build": "echo noop",
     "test": "jest --runInBand",
     "test:ci": "jest --runInBand --coverage"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
     "jest": "^26.6.3",
-    "npm-run-all": "^4.1.5",
     "object-hash": "^2.2.0",
     "uuid": "^8.3.2"
   }

--- a/integration-tests/test/bot-broker-runner.test.ts
+++ b/integration-tests/test/bot-broker-runner.test.ts
@@ -3,26 +3,13 @@ import * as path from 'path';
 import nock, { Scope } from 'nock';
 import { URL } from 'url';
 import { createProbot, Probot, ProbotOctokit } from 'probot';
-import { v4 as mkuuid } from 'uuid';
-import { inspect } from 'util';
 
-import { Auth, AuthScope } from '../../modules/broker/src/auth';
 import { Broker } from '../../modules/broker/src/broker';
 import { GithubClient } from '../../modules/bot/src/github-client';
 import { Runner } from '../../modules/runner/src/runner';
 import { Server as BrokerServer } from '../../modules/broker/src/server';
-import { Labels } from '../../modules/bot/src/github-labels';
-import { Task } from '../../modules/broker/src/task';
 
-import {
-  BisectJob,
-  Current,
-  JobType,
-  Platform,
-  Result,
-  TestJob,
-  VersionRange,
-} from '@electron/bugbot-shared/build/interfaces';
+import { Platform } from '@electron/bugbot-shared/build/interfaces';
 
 jest.setTimeout(60_000);
 
@@ -37,7 +24,6 @@ describe('bot-broker-runner', () => {
   let ghclient: GithubClient;
   let robot: Probot;
   let ghNockScope: Scope;
-  let brokerNockScope: Scope;
   function startProbot() {
     robot = createProbot({
       overrides: {
@@ -128,24 +114,28 @@ describe('bot-broker-runner', () => {
     expect(brokerServer.brokerUrl).toStrictEqual(new URL(brokerUrl));
   });
 
-
   it('bisects', async () => {
     const botCommentId = 1 as const;
     const issueNumber = 10 as const;
     const projectPath = '/repos/erickzhao/bugbot' as const;
     const issuePath = `${projectPath}/issues/${issueNumber}` as const;
-    const botComment = { id: botCommentId, user: { login: `${process.env.BUGBOT_GITHUB_LOGIN}[bot]` } };
     ghNockScope = nock('https://api.github.com');
     ghNockScope
       .get(`${projectPath}/collaborators/erickzhao/permission`)
       .reply(200, { permission: 'admin' })
-      .post(`${issuePath}/labels`).reply(200)
+      .post(`${issuePath}/labels`)
+      .reply(200)
       // create a new comment:
-      .post(`${issuePath}/comments`).reply(200, { id: botCommentId })
-      .delete(`${issuePath}/labels/bugbot%2Ftest-running`).reply(200)
+      .post(`${issuePath}/comments`)
+      .reply(200, { id: botCommentId })
+      .delete(`${issuePath}/labels/bugbot%2Ftest-running`)
+      .reply(200)
       // ... task runs...
-      .post(`${issuePath}/labels`).reply(200)
-      .patch(`${projectPath}/issues/comments/${botCommentId}`).reply(200); // update the comment
+      .post(`${issuePath}/labels`)
+      .reply(200)
+      // update the comment
+      .patch(`${projectPath}/issues/comments/${botCommentId}`)
+      .reply(200);
 
     await startWithDefaults();
     const filename = path.join(fixtureDir, 'issue_comment.created.bisect.json');
@@ -156,21 +146,25 @@ describe('bot-broker-runner', () => {
 
     const tasks = broker.getTasks();
     expect(tasks.length).toBe(1);
-    expect(tasks).toMatchObject([{
-      job: {
-        gist: '59444f92bffd5730944a0de6d85067fd',
-        history: [{
-          status: 'success',
-          version_range: ['10.3.2', '10.4.0'],
-        }],
-        last: {
-          status: 'success',
-          version_range: ['10.3.2', '10.4.0'],
+    expect(tasks).toMatchObject([
+      {
+        job: {
+          gist: '59444f92bffd5730944a0de6d85067fd',
+          history: [
+            {
+              status: 'success',
+              version_range: ['10.3.2', '10.4.0'],
+            },
+          ],
+          last: {
+            status: 'success',
+            version_range: ['10.3.2', '10.4.0'],
+          },
+          type: 'bisect',
+          version_range: ['10.1.6', '11.0.2'],
         },
-        type: 'bisect',
-        version_range: ['10.1.6', '11.0.2'],
-      }
-    }]);
+      },
+    ]);
   });
 
   it('tests', async () => {
@@ -178,9 +172,9 @@ describe('bot-broker-runner', () => {
     const issueNumber = 10 as const;
     const projectPath = '/repos/erickzhao/bugbot' as const;
     const issuePath = `${projectPath}/issues/${issueNumber}` as const;
-    const botComment = { id: botCommentId, user: { login: `${process.env.BUGBOT_GITHUB_LOGIN}[bot]` } };
 
-    const electronJsNockscope = nock('https://electronjs.org/')
+    const electronJsNockScope = nock('https://electronjs.org/');
+    electronJsNockScope
       .get('/headers/index.json')
       .replyWithFile(200, __dirname + '/fixtures/electron-versions.json', {
         'Content-Type': 'application/json',
@@ -192,9 +186,11 @@ describe('bot-broker-runner', () => {
       .get(`${projectPath}/collaborators/erickzhao/permission`)
       .reply(200, { permission: 'admin' })
       // create a new comment:
-      .post(`${issuePath}/comments`).reply(200, { id: botCommentId })
+      .post(`${issuePath}/comments`)
+      .reply(200, { id: botCommentId })
       // and when the test is finished, update the comment
-      .patch(`${projectPath}/issues/comments/${botCommentId}`).reply(200);
+      .patch(`${projectPath}/issues/comments/${botCommentId}`)
+      .reply(200);
 
     const filename = path.join(fixtureDir, 'issue_comment.created.test.json');
     await startWithDefaults();
@@ -205,23 +201,25 @@ describe('bot-broker-runner', () => {
 
     const tasks = broker.getTasks();
     expect(tasks.length).toBe(1);
-    expect(tasks).toMatchObject([{
-      job: {
-        gist: '59444f92bffd5730944a0de6d85067fd',
-        history: [
-          {
+    expect(tasks).toMatchObject([
+      {
+        job: {
+          gist: '59444f92bffd5730944a0de6d85067fd',
+          history: [
+            {
+              status: 'failure',
+              error: 'The test ran and failed.',
+            },
+          ],
+          type: 'test',
+          version: '12.0.0',
+          platform: 'linux',
+          last: {
             status: 'failure',
             error: 'The test ran and failed.',
           },
-        ],
-        type: 'test',
-        version: '12.0.0',
-        platform: 'linux',
-        last: {
-          status: 'failure',
-          error: 'The test ran and failed.',
         },
       },
-    }]);
+    ]);
   });
 });

--- a/integration-tests/tsconfig.eslint.json
+++ b/integration-tests/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts", "test/**/*.json"]
+}

--- a/integration-tests/tsconfig.json
+++ b/integration-tests/tsconfig.json
@@ -1,15 +1,9 @@
 {
   "extends": "@electron/bugbot-shared/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/.tsbuildinfo",
+    "outDir": "build",
+    "tsBuildInfoFile": "build/.tsbuildinfo",
     "rootDir": "src"
   },
-  "include": ["src/**/*"],
-  "references": [
-    { "path": "../modules/bot" },
-    { "path": "../modules/broker" },
-    { "path": "../modules/runner" },
-    { "path": "../modules/shared" }
-  ]
+  "include": [],
 }

--- a/modules/shared/tsconfig.base.json
+++ b/modules/shared/tsconfig.base.json
@@ -6,6 +6,7 @@
   "compilerOptions": {
     "composite": true,
     "declaration": true, // required by "composite"
+    "downlevelIteration": true,
     "target": "ES2019",
     "lib": [
       "ES2019"


### PR DESCRIPTION
Re-fix linting in `integration-tests/`.

Config changes:

1. Fix side-effects introduced by #141. That PR did fix the PowerShell issue, but introduced a side-effect that "yarn build" created unwanted .js files for integration tests. This PR goes back to making integration-tests' "yarn build" a no-op, but this time uses a more cross-platform no-op: `"build": "run-p -s"` (do nothing, and do it silently).

2. The integration tests directory was hitting the same include/exclude issue we've had in other submodules. Fixed by using the same dual tsconfig approach as the other submodules (see #99). (This is slightly odd here since there are no non-test files, but has the advantage of consistency with the rest of the repo)

3. Add `downlevelIteration: true` to the shared base tsconfig file so that eslint is OK with code [like this](https://github.com/electron/bugbot/blob/4d31e3bdb1607756a4063734d8a00a691f2f2741/integration-tests/test/bot-broker-runner.test.ts#L113):

```ts
const values = [...someMap.values()];
```

Also, fix the bot-broker-runner linter warnings that showed up now that eslint is running again. No major changes here; mostly it's removing unused imports & fixing prettier whitespace.