### PR TITLE
fix: use the issue URL instead of unique issue ID

### DIFF
--- a/modules/bot/src/github-client.ts
+++ b/modules/bot/src/github-client.ts
@@ -127,7 +127,7 @@ export class GithubClient {
           {
             event: 'run_job',
             kind: 'bisect',
-            issue_id: issue.id,
+            issue_url: issue.html_url,
           },
           { module: 'bot' },
         );
@@ -137,7 +137,7 @@ export class GithubClient {
           {
             event: 'run_job',
             kind: 'test_matrix',
-            issue_id: issue.id,
+            issue_url: issue.html_url,
           },
           { module: 'bot' },
         );


### PR DESCRIPTION
The `issue.id` field was unique across all issues everywhere, which isn't exactly what we wanted. Instead, use the user-friendly issue URL.