### PR TITLE
feat: add os-specific bisect to bot

### DIFF
--- a/modules/bot/src/broker-client.ts
+++ b/modules/bot/src/broker-client.ts
@@ -35,6 +35,7 @@ export default class BrokerAPI {
       gist: command.gistId,
       history: [],
       id: mkuuid(),
+      platform: command.platform,
       time_added: Date.now(),
       type: JobType.bisect,
       version_range: [command.goodVersion, command.badVersion],

--- a/modules/bot/src/issue-parser.ts
+++ b/modules/bot/src/issue-parser.ts
@@ -8,7 +8,10 @@ import { inspect } from 'util';
 
 import { Versions, compareVersions } from 'fiddle-core';
 
-import { Platform } from '@electron/bugbot-shared/build/interfaces';
+import {
+  ALL_PLATFORMS,
+  Platform,
+} from '@electron/bugbot-shared/build/interfaces';
 
 // no types exist for this module
 //eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -90,8 +93,6 @@ const ISSUE_SECTIONS = {
   gistId: 'Testcase Gist URL',
   platform: 'What operating system are you using?',
 };
-
-const ALL_PLATFORMS: Platform[] = ['darwin', 'linux', 'win32'];
 
 export function isValidPlatform(value: string): value is Platform {
   return ALL_PLATFORMS.includes(value as Platform);

--- a/modules/bot/src/issue-parser.ts
+++ b/modules/bot/src/issue-parser.ts
@@ -154,7 +154,7 @@ function parseBisectCommand(
   }
 
   d('%o', { badVersion, gistId, goodVersion, platform });
-  return badVersion && gistId && goodVersion && platform
+  return badVersion && gistId && goodVersion
     ? {
         badVersion: badVersion?.version,
         gistId,

--- a/modules/bot/test/issue-parser.spec.ts
+++ b/modules/bot/test/issue-parser.spec.ts
@@ -175,6 +175,7 @@ describe('issue-parser', () => {
         badVersion: '13.0.0',
         gistId: fixtureGistId,
         goodVersion: '12.0.0',
+        platform: 'win32',
         type: 'bisect',
       };
 
@@ -183,7 +184,7 @@ describe('issue-parser', () => {
         expect(otherBadVersion).not.toBe(expectedCommand.badVersion);
       });
 
-      it('finds a gist and version range', () => {
+      it('finds a gist, version range, and platform', () => {
         const issueBody = getIssueBody('issue.md');
         const command = parseIssueCommand(issueBody, COMMENT, versions);
         expect(command).toStrictEqual(expectedCommand);
@@ -254,6 +255,33 @@ describe('issue-parser', () => {
         });
       });
 
+      it('reads a platform from the issue comment', () => {
+        const issueBody = getIssueBody('issue.md');
+        const comment = `${COMMENT} darwin`;
+        const command = parseIssueCommand(issueBody, comment, versions);
+        expect(command).toStrictEqual({
+          ...expectedCommand,
+          platform: 'darwin',
+        });
+      });
+
+      it.each([
+        ['linux', 'Ubuntu'],
+        ['darwin', 'OSX'],
+        ['win32', 'Windows'],
+      ])(
+        'can match an approximate platform name for %s in the issue comment',
+        (platform, approximateName) => {
+          const issueBody = getIssueBody('issue.md');
+          const comment = `${COMMENT} ${approximateName}`;
+          const command = parseIssueCommand(issueBody, comment, versions);
+          expect(command).toStrictEqual({
+            ...expectedCommand,
+            platform,
+          });
+        },
+      );
+
       it('ignores inscrutable comment arguments', () => {
         const issueBody = getIssueBody('issue.md');
         const comment = `${COMMENT} fnord`;
@@ -279,7 +307,7 @@ describe('issue-parser', () => {
         expect(command).toStrictEqual({
           ...expectedCommand,
           goodVersion: fakeBisectStart,
-          badVersion: fakeLatestVersion
+          badVersion: fakeLatestVersion,
         });
       });
 

--- a/modules/shared/src/interfaces.ts
+++ b/modules/shared/src/interfaces.ts
@@ -16,8 +16,13 @@ const JobIdPredicate = ow.string.validate((str) => ({
   message: `Expected value to be a UUID, got ${str}`,
 }));
 
-export type Platform = 'darwin' | 'linux' | 'win32';
-const PlatformPredicate = ow.string.oneOf(['darwin', 'linux', 'win32']);
+// Editing `PLATFORM_LIST` should automatically update the constants after it,
+// including the `Platform` type thanks to some type magic :)
+const PLATFORM_LIST = ['darwin', 'linux', 'win32'] as const;
+
+export type Platform = typeof PLATFORM_LIST[number];
+export const ALL_PLATFORMS: readonly Platform[] = PLATFORM_LIST;
+const PlatformPredicate = ow.string.oneOf(ALL_PLATFORMS);
 
 export type RunnerId = string;
 const RunnerIdPredicate = ow.string;


### PR DESCRIPTION
Closes #157 

Also does some preliminary work on #177, but doesn't extend it to the `/test` command.